### PR TITLE
Analyze supabase call increase on refresh

### DIFF
--- a/src/server/jobs/job-manager.ts
+++ b/src/server/jobs/job-manager.ts
@@ -18,10 +18,11 @@ export class JobManager {
   private get config() {
     return {
       connectionString: process.env.PG_BOSS_DATABASE_URL!,
-      // Optimized for production scalability
-      newJobCheckIntervalSeconds: Number(process.env.PG_BOSS_POLLING_INTERVAL ?? '30'),
-      maintenanceIntervalSeconds: Number(process.env.PG_BOSS_MAINTENANCE_INTERVAL ?? '600'),
-      monitorStateIntervalSeconds: Number(process.env.PG_BOSS_MONITOR_INTERVAL ?? '300'),
+      // PURE EVENT-DRIVEN: Disable polling entirely by setting extremely high intervals
+      // Job processing is now driven by PostgreSQL LISTEN/NOTIFY events
+      newJobCheckIntervalSeconds: Number(process.env.PG_BOSS_POLLING_INTERVAL ?? '86400'), // 24 hours - effectively disabled
+      maintenanceIntervalSeconds: Number(process.env.PG_BOSS_MAINTENANCE_INTERVAL ?? '86400'), // 24 hours - effectively disabled
+      monitorStateIntervalSeconds: Number(process.env.PG_BOSS_MONITOR_INTERVAL ?? '86400'), // 24 hours - effectively disabled
       
       // Robust error handling
       deleteAfterDays: Number(process.env.PG_BOSS_DELETE_AFTER_DAYS ?? '7'),

--- a/src/server/jobs/pgboss-client.ts
+++ b/src/server/jobs/pgboss-client.ts
@@ -23,8 +23,8 @@ export async function getBoss(): Promise<PgBoss> {
     // PURE EVENT-DRIVEN: Disable polling entirely by setting extremely high intervals
     // Job processing is now driven by PostgreSQL LISTEN/NOTIFY events
     newJobCheckIntervalSeconds: 86400, // 24 hours - effectively disabled
-    maintenanceIntervalSeconds: Number(process.env.PG_BOSS_MAINTENANCE_INTERVAL_SECONDS ?? '3600'), // 1 hour for cleanup
-    monitorStateIntervalSeconds: Number(process.env.PG_BOSS_MONITOR_STATE_INTERVAL_SECONDS ?? '3600'), // 1 hour for monitoring
+    maintenanceIntervalSeconds: Number(process.env.PG_BOSS_MAINTENANCE_INTERVAL_SECONDS ?? '86400'), // 24 hours - effectively disabled
+    monitorStateIntervalSeconds: Number(process.env.PG_BOSS_MONITOR_STATE_INTERVAL_SECONDS ?? '86400'), // 24 hours - effectively disabled
     
     // Event-driven system provides instant job processing via LISTEN/NOTIFY
     // This eliminates the ~185k polling database calls we were seeing


### PR DESCRIPTION
Disable pgBoss polling to drastically reduce database calls.

This change sets the `newJobCheckIntervalSeconds`, `maintenanceIntervalSeconds`, and `monitorStateIntervalSeconds` for both pgBoss instances to 24 hours (86400 seconds), effectively disabling polling. This ensures job processing is purely event-driven via PostgreSQL LISTEN/NOTIFY, eliminating the high volume of unnecessary polling queries previously observed.

---
<a href="https://cursor.com/background-agent?bcId=bc-60480a84-e616-4d87-8f25-a78a3349356e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-60480a84-e616-4d87-8f25-a78a3349356e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

