### PR TITLE
Investigate frontend workspace node glitches and disconnections

### DIFF
--- a/src/components/workspace/flow/hooks/use-connections.ts
+++ b/src/components/workspace/flow/hooks/use-connections.ts
@@ -9,6 +9,7 @@ export function useConnections(
   edges: Edge[],
   setEdges: (updater: Edge[] | ((eds: Edge[]) => Edge[])) => void,
   flowTracker: FlowTracker,
+  updateContextEdges?: (newEdges: Edge[]) => void,
 ) {
   // Toast notifications removed for connections as they're frequent user actions
 
@@ -50,9 +51,10 @@ export function useConnections(
     );
 
     setEdges(newEdges);
+    if (updateContextEdges) updateContextEdges(newEdges);
     
     // No success toast for connections - they're frequent user actions
-  }, [nodes, edges, setEdges, flowTracker]);
+  }, [nodes, edges, setEdges, flowTracker, updateContextEdges]);
 
   return { onConnect } as const;
 }


### PR DESCRIPTION
Fixes node movement glitches and connection loss by optimizing state synchronization during drag operations.

Previously, node movements triggered frequent, heavy state updates (like snapshotting for "unsaved changes") on every drag event, causing UI stutters. Additionally, newly created connections were lost upon node movement because they were not immediately synced to the global context, allowing stale context data to overwrite them. This PR ensures connections are immediately persisted and defers node state synchronization until the drag operation completes, eliminating performance bottlenecks and data loss.

---
<a href="https://cursor.com/background-agent?bcId=bc-eb40b9ce-b2f7-4a77-9fe9-89135fd3ace8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-eb40b9ce-b2f7-4a77-9fe9-89135fd3ace8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

