### PR TITLE
Understand canvas and timeline bindable properties

### DIFF
--- a/src/components/ui/form-fields.tsx
+++ b/src/components/ui/form-fields.tsx
@@ -193,6 +193,7 @@ interface SelectFieldProps {
 	required?: boolean;
 	error?: string;
 	className?: string;
+	bindAdornment?: React.ReactNode;
 }
 
 export function SelectField({
@@ -202,20 +203,29 @@ export function SelectField({
 	options,
 	required = true,
 	error,
-	className
+	className,
+	bindAdornment
 }: SelectFieldProps) {
 	return (
 		<FormField label={label} required={required} error={error} className={className}>
-			<Select
-				value={value}
-				onChange={(e) => onChange(e.target.value)}
-			>
-				{options.map(option => (
-					<option key={option.value} value={option.value}>
-						{option.label}
-					</option>
-				))}
-			</Select>
+			<div className="relative">
+				<Select
+					value={value}
+					onChange={(e) => onChange(e.target.value)}
+					className={bindAdornment ? 'pr-9' : undefined}
+				>
+					{options.map(option => (
+						<option key={option.value} value={option.value}>
+							{option.label}
+						</option>
+					))}
+				</Select>
+				{bindAdornment && (
+					<div className="absolute right-2 top-1/2 -translate-y-1/2">
+						{bindAdornment}
+					</div>
+				)}
+			</div>
 		</FormField>
 	);
 }

--- a/src/components/workspace/binding/bindings.tsx
+++ b/src/components/workspace/binding/bindings.tsx
@@ -1,0 +1,124 @@
+import React, { useMemo, useState } from 'react';
+import { Link as LinkIcon } from 'lucide-react';
+import { useWorkspace } from '@/components/workspace/workspace-context';
+import { FlowTracker } from '@/lib/flow/flow-tracking';
+
+interface BindButtonProps {
+	nodeId: string;
+	bindingKey: string;
+	objectId?: string;
+	className?: string;
+}
+
+function useVariableBinding(nodeId: string, objectId?: string) {
+	const { state, updateFlow } = useWorkspace();
+
+	const variables = useMemo(() => {
+		const tracker = new FlowTracker();
+		return tracker.getAvailableResultVariables(nodeId, state.flow.nodes as any, state.flow.edges as any);
+	}, [nodeId, state.flow.nodes, state.flow.edges]);
+
+	const getBinding = (key: string): string | undefined => {
+		const node = state.flow.nodes.find(n => (n as any).data?.identifier?.id === nodeId) as any;
+		if (!node) return undefined;
+		if (objectId) {
+			const prevAll = (node?.data?.variableBindingsByObject ?? {}) as Record<string, Record<string, { boundResultNodeId?: string }>>;
+			return prevAll?.[objectId]?.[key]?.boundResultNodeId;
+		}
+		const vb = (node?.data?.variableBindings ?? {}) as Record<string, { boundResultNodeId?: string }>;
+		return vb?.[key]?.boundResultNodeId;
+	};
+
+	const getBoundName = (rid?: string): string | undefined => {
+		if (!rid) return undefined;
+		const node = state.flow.nodes.find(n => (n as any).data?.identifier?.id === rid) as any;
+		return node?.data?.identifier?.displayName as string | undefined;
+	};
+
+	const bind = (key: string, resultNodeId: string) => {
+		updateFlow({
+			nodes: state.flow.nodes.map((n) => {
+				if (((n as any).data?.identifier?.id) !== nodeId) return n;
+				if (objectId) {
+					const prevAll = ((n as any).data?.variableBindingsByObject ?? {}) as Record<string, Record<string, { target?: string; boundResultNodeId?: string }>>;
+					const prev = prevAll[objectId] ?? {};
+					const nextObj = { ...prev, [key]: { target: key, boundResultNodeId: resultNodeId } };
+					return { ...n, data: { ...(n as any).data, variableBindingsByObject: { ...prevAll, [objectId]: nextObj } } } as any;
+				}
+				const prev = ((n as any).data?.variableBindings ?? {}) as Record<string, { target?: string; boundResultNodeId?: string }>;
+				const next = { ...prev, [key]: { target: key, boundResultNodeId: resultNodeId } };
+				return { ...n, data: { ...(n as any).data, variableBindings: next } } as any;
+			})
+		});
+	};
+
+	const clear = (key: string) => {
+		updateFlow({
+			nodes: state.flow.nodes.map((n) => {
+				if (((n as any).data?.identifier?.id) !== nodeId) return n;
+				if (objectId) {
+					const prevAll = ((n as any).data?.variableBindingsByObject ?? {}) as Record<string, Record<string, { target?: string; boundResultNodeId?: string }>>;
+					const prev = { ...(prevAll[objectId] ?? {}) };
+					delete prev[key];
+					return { ...n, data: { ...(n as any).data, variableBindingsByObject: { ...prevAll, [objectId]: prev } } } as any;
+				}
+				const prev = ((n as any).data?.variableBindings ?? {}) as Record<string, { target?: string; boundResultNodeId?: string }>;
+				const next = { ...prev } as typeof prev;
+				delete next[key];
+				return { ...n, data: { ...(n as any).data, variableBindings: next } } as any;
+			})
+		});
+	};
+
+	return { variables, getBinding, getBoundName, bind, clear } as const;
+}
+
+export function BindButton({ nodeId, bindingKey, objectId, className }: BindButtonProps) {
+	const { variables, getBinding, getBoundName, bind, clear } = useVariableBinding(nodeId, objectId);
+	const [open, setOpen] = useState(false);
+	const boundId = getBinding(bindingKey);
+	const boundName = getBoundName(boundId);
+
+	return (
+		<div className={`relative ${className ?? ''}`}>
+			<button
+				type="button"
+				title={boundId ? `Bound to ${boundName ?? boundId}` : 'Bind to Result variable'}
+				onClick={() => setOpen(v => !v)}
+				className={`p-1 rounded hover:bg-[var(--surface-interactive)] ${boundId ? 'text-[var(--accent-500)]' : ''}`}
+			>
+				<LinkIcon size={14} />
+			</button>
+			{open && (
+				<div className="absolute right-0 z-50 mt-1 bg-[var(--surface-2)] border border-[var(--border-primary)] rounded shadow-md min-w-[180px]">
+					{variables.length === 0 ? (
+						<div className="px-3 py-2 text-xs text-[var(--text-tertiary)]">No connected Result variables</div>
+					) : (
+						<div className="max-h-56 overflow-auto">
+							{variables.map(v => (
+								<div
+									key={v.id}
+									className="px-3 py-2 text-xs hover:bg-[var(--surface-interactive)] cursor-pointer"
+									onClick={() => { bind(bindingKey, v.id); setOpen(false); }}
+								>
+									{v.name}
+								</div>
+							))}
+						</div>
+					)}
+					{boundId && (
+						<>
+							<div className="h-px bg-[var(--border-primary)]" />
+							<div
+								className="px-3 py-2 text-xs text-[var(--danger-400)] hover:bg-[var(--surface-interactive)] cursor-pointer"
+								onClick={() => { clear(bindingKey); setOpen(false); }}
+							>
+								Clear binding
+							</div>
+						</>
+					)}
+				</div>
+			)}
+		</div>
+	);
+}

--- a/src/components/workspace/canvas-editor-tab.tsx
+++ b/src/components/workspace/canvas-editor-tab.tsx
@@ -10,6 +10,7 @@ import { NumberField, ColorField } from '@/components/ui/form-fields';
 import { EditorShell } from './common/editor-shell';
 import { ObjectSelectionPanel } from './common/object-selection-panel';
 import { Link as LinkIcon } from 'lucide-react';
+import { BindButton } from '@/components/workspace/binding/bindings';
 
 export function CanvasEditorTab({ nodeId }: { nodeId: string }) {
 	const { state, updateUI, updateFlow } = useWorkspace();
@@ -148,51 +149,12 @@ function CanvasDefaultProperties({ nodeId }: { nodeId: string }) {
 	};
 	const bindings = (data.variableBindings ?? {}) as Record<string, { target?: string; boundResultNodeId?: string }>;
 
-	const variables = (() => {
-		const tracker = new FlowTracker();
-		return tracker.getAvailableResultVariables(nodeId, state.flow.nodes as any, state.flow.edges as any);
-	})();
-
-	const [openMenu, setOpenMenu] = useState<string | null>(null);
-	const bindButton = (key: string) => (
-		<div className="relative inline-block">
-			<button className="p-1 rounded hover:bg-[var(--surface-interactive)]" title="Bind to Result variable" onClick={() => setOpenMenu(prev => prev === key ? null : key)}>
-				<LinkIcon size={14} />
-			</button>
-			{openMenu === key && (
-				<div className="absolute right-0 z-10 mt-1 bg-[var(--surface-2)] border border-[var(--border-primary)] rounded shadow-md min-w-[160px]">
-					{variables.length === 0 ? (
-						<div className="px-3 py-2 text-xs text-[var(--text-tertiary)]">No connected Result variables</div>
-					) : variables.map(v => (
-						<div key={v.id} className="px-3 py-2 text-xs hover:bg-[var(--surface-interactive)] cursor-pointer" onClick={() => {
-							persistBinding(key, v.id);
-							setOpenMenu(null);
-						}}>
-							{v.name}
-						</div>
-					))}
-				</div>
-			)}
-		</div>
-	);
-
-	const persistBinding = (key: string, resultNodeId: string) => {
-		updateFlow({
-			nodes: state.flow.nodes.map((n) => {
-				if (((n as any).data?.identifier?.id) !== nodeId) return n;
-				const prev = ((n as any).data?.variableBindings ?? {}) as Record<string, { target?: string; boundResultNodeId?: string }>;
-				const next = { ...prev, [key]: { target: key, boundResultNodeId: resultNodeId } };
-				return { ...n, data: { ...(n as any).data, variableBindings: next } } as any;
-			})
-		});
-	};
-
 	return (
 		<div className="space-y-[var(--space-2)]">
 			<div className="grid grid-cols-2 gap-[var(--space-2)]">
 				<div>
 					<label className="block text-xs text-[var(--text-tertiary)]">Position X</label>
-					<NumberField label="" value={(data.position?.x as number) ?? NaN} onChange={(x) => updateFlow({ nodes: state.flow.nodes.map(n => ((n as any).data?.identifier?.id) !== nodeId ? n : ({ ...n, data: { ...(n as any).data, position: { x, y: (data.position?.y ?? 0) } } } as any)) })} defaultValue={0} bindAdornment={bindButton('position')} />
+					<NumberField label="" value={(data.position?.x as number) ?? NaN} onChange={(x) => updateFlow({ nodes: state.flow.nodes.map(n => ((n as any).data?.identifier?.id) !== nodeId ? n : ({ ...n, data: { ...(n as any).data, position: { x, y: (data.position?.y ?? 0) } } } as any)) })} defaultValue={0} bindAdornment={<BindButton nodeId={nodeId} bindingKey="position" />} />
 				</div>
 				<div>
 					<label className="block text-xs text-[var(--text-tertiary)]">Position Y</label>
@@ -202,7 +164,7 @@ function CanvasDefaultProperties({ nodeId }: { nodeId: string }) {
 			<div className="grid grid-cols-2 gap-[var(--space-2)]">
 				<div>
 					<label className="block text-xs text-[var(--text-tertiary)]">Scale X</label>
-					<NumberField label="" value={(data.scale?.x as number) ?? NaN} onChange={(x) => updateFlow({ nodes: state.flow.nodes.map(n => ((n as any).data?.identifier?.id) !== nodeId ? n : ({ ...n, data: { ...(n as any).data, scale: { x, y: (data.scale?.y ?? 1) } } } as any)) })} defaultValue={1} min={0} step={0.1} bindAdornment={bindButton('scale')} />
+					<NumberField label="" value={(data.scale?.x as number) ?? NaN} onChange={(x) => updateFlow({ nodes: state.flow.nodes.map(n => ((n as any).data?.identifier?.id) !== nodeId ? n : ({ ...n, data: { ...(n as any).data, scale: { x, y: (data.scale?.y ?? 1) } } } as any)) })} defaultValue={1} min={0} step={0.1} bindAdornment={<BindButton nodeId={nodeId} bindingKey="scale" />} />
 				</div>
 				<div>
 					<label className="block text-xs text-[var(--text-tertiary)]">Scale Y</label>
@@ -212,22 +174,22 @@ function CanvasDefaultProperties({ nodeId }: { nodeId: string }) {
 			<div className="grid grid-cols-2 gap-[var(--space-2)]">
 				<div>
 					<label className="block text-xs text-[var(--text-tertiary)]">Rotation</label>
-					<NumberField label="" value={(data.rotation as number) ?? NaN} onChange={(rotation) => updateFlow({ nodes: state.flow.nodes.map(n => ((n as any).data?.identifier?.id) !== nodeId ? n : ({ ...n, data: { ...(n as any).data, rotation } } as any)) })} step={0.1} defaultValue={0} bindAdornment={bindButton('rotation')} />
+					<NumberField label="" value={(data.rotation as number) ?? NaN} onChange={(rotation) => updateFlow({ nodes: state.flow.nodes.map(n => ((n as any).data?.identifier?.id) !== nodeId ? n : ({ ...n, data: { ...(n as any).data, rotation } } as any)) })} step={0.1} defaultValue={0} bindAdornment={<BindButton nodeId={nodeId} bindingKey="rotation" />} />
 				</div>
 				<div>
 					<label className="block text-xs text-[var(--text-tertiary)]">Opacity</label>
-					<NumberField label="" value={(data.opacity as number) ?? NaN} onChange={(opacity) => updateFlow({ nodes: state.flow.nodes.map(n => ((n as any).data?.identifier?.id) !== nodeId ? n : ({ ...n, data: { ...(n as any).data, opacity } } as any)) })} min={0} max={1} step={0.05} defaultValue={1} bindAdornment={bindButton('opacity')} />
+					<NumberField label="" value={(data.opacity as number) ?? NaN} onChange={(opacity) => updateFlow({ nodes: state.flow.nodes.map(n => ((n as any).data?.identifier?.id) !== nodeId ? n : ({ ...n, data: { ...(n as any).data, opacity } } as any)) })} min={0} max={1} step={0.05} defaultValue={1} bindAdornment={<BindButton nodeId={nodeId} bindingKey="opacity" />} />
 				</div>
 			</div>
 			<div className="grid grid-cols-3 gap-[var(--space-2)] items-end">
 				<div>
-					<ColorField label="Fill" value={(data.fillColor as string) ?? ''} onChange={(fillColor) => updateFlow({ nodes: state.flow.nodes.map(n => ((n as any).data?.identifier?.id) !== nodeId ? n : ({ ...n, data: { ...(n as any).data, fillColor } } as any)) })} bindAdornment={bindButton('fillColor')} />
+					<ColorField label="Fill" value={(data.fillColor as string) ?? ''} onChange={(fillColor) => updateFlow({ nodes: state.flow.nodes.map(n => ((n as any).data?.identifier?.id) !== nodeId ? n : ({ ...n, data: { ...(n as any).data, fillColor } } as any)) })} bindAdornment={<BindButton nodeId={nodeId} bindingKey="fillColor" />} />
 				</div>
 				<div>
-					<ColorField label="Stroke" value={(data.strokeColor as string) ?? ''} onChange={(strokeColor) => updateFlow({ nodes: state.flow.nodes.map(n => ((n as any).data?.identifier?.id) !== nodeId ? n : ({ ...n, data: { ...(n as any).data, strokeColor } } as any)) })} bindAdornment={bindButton('strokeColor')} />
+					<ColorField label="Stroke" value={(data.strokeColor as string) ?? ''} onChange={(strokeColor) => updateFlow({ nodes: state.flow.nodes.map(n => ((n as any).data?.identifier?.id) !== nodeId ? n : ({ ...n, data: { ...(n as any).data, strokeColor } } as any)) })} bindAdornment={<BindButton nodeId={nodeId} bindingKey="strokeColor" />} />
 				</div>
 				<div>
-					<NumberField label="Stroke W" value={(data.strokeWidth as number) ?? NaN} onChange={(strokeWidth) => updateFlow({ nodes: state.flow.nodes.map(n => ((n as any).data?.identifier?.id) !== nodeId ? n : ({ ...n, data: { ...(n as any).data, strokeWidth } } as any)) })} min={0} step={0.5} defaultValue={1} bindAdornment={bindButton('strokeWidth')} />
+					<NumberField label="Stroke W" value={(data.strokeWidth as number) ?? NaN} onChange={(strokeWidth) => updateFlow({ nodes: state.flow.nodes.map(n => ((n as any).data?.identifier?.id) !== nodeId ? n : ({ ...n, data: { ...(n as any).data, strokeWidth } } as any)) })} min={0} step={0.5} defaultValue={1} bindAdornment={<BindButton nodeId={nodeId} bindingKey="strokeWidth" />} />
 				</div>
 			</div>
 		</div>
@@ -258,55 +220,6 @@ function CanvasPerObjectProperties({ nodeId, objectId, assignments, onChange, on
 	};
 
 	const { state, updateFlow } = useWorkspace();
-	// Variable bindings per-object
-	const variables = (() => {
-		const tracker = new FlowTracker();
-		return tracker.getAvailableResultVariables(nodeId, state.flow.nodes as any, state.flow.edges as any);
-	})();
-	const [openMenu, setOpenMenu] = useState<string | null>(null);
-	const bindButton = (key: string) => (
-		<div className="relative inline-block">
-			<button className="p-1 rounded hover:bg-[var(--surface-interactive)]" title="Bind to Result variable" onClick={() => setOpenMenu(prev => prev === key ? null : key)}>
-				<LinkIcon size={14} />
-			</button>
-			{openMenu === key && (
-				<div className="absolute right-0 z-10 mt-1 bg-[var(--surface-2)] border border-[var(--border-primary)] rounded shadow-md min-w-[160px]">
-					{variables.length === 0 ? (
-						<div className="px-3 py-2 text-xs text-[var(--text-tertiary)]">No connected Result variables</div>
-					) : variables.map(v => (
-						<div key={v.id} className="px-3 py-2 text-xs hover:bg-[var(--surface-interactive)] cursor-pointer" onClick={() => {
-							persistBinding(key, v.id);
-							setOpenMenu(null);
-						}}>
-							{v.name}
-						</div>
-					))}
-				</div>
-			)}
-		</div>
-	);
-	const persistBinding = (key: string, resultNodeId: string) => {
-		updateFlow({
-			nodes: state.flow.nodes.map((n) => {
-				if (((n as any).data?.identifier?.id) !== nodeId) return n;
-				const prevAll = ((n as any).data?.variableBindingsByObject ?? {}) as Record<string, Record<string, { target?: string; boundResultNodeId?: string }>>;
-				const prev = prevAll[objectId] ?? {};
-				const nextObj = { ...prev, [key]: { target: key, boundResultNodeId: resultNodeId } };
-				return { ...n, data: { ...(n as any).data, variableBindingsByObject: { ...prevAll, [objectId]: nextObj } } } as any;
-			})
-		});
-	};
-	const clearBinding = (key: string) => {
-		updateFlow({
-			nodes: state.flow.nodes.map((n) => {
-				if (((n as any).data?.identifier?.id) !== nodeId) return n;
-				const prevAll = ((n as any).data?.variableBindingsByObject ?? {}) as Record<string, Record<string, { target?: string; boundResultNodeId?: string }>>;
-				const prev = { ...(prevAll[objectId] ?? {}) };
-				delete prev[key];
-				return { ...n, data: { ...(n as any).data, variableBindingsByObject: { ...prevAll, [objectId]: prev } } } as any;
-			})
-		});
-	};
 	const BindingTag = ({ keyName }: { keyName: string }) => {
 		const node = state.flow.nodes.find(n => (n as any).data?.identifier?.id === nodeId) as any;
 		const vbAll = (node?.data?.variableBindingsByObject ?? {}) as Record<string, Record<string, { boundResultNodeId?: string }>>;
@@ -316,7 +229,17 @@ function CanvasPerObjectProperties({ nodeId, objectId, assignments, onChange, on
 		return <span className="ml-2 text-[10px] text-[var(--text-tertiary)]">(bound: {name ?? bound})</span>;
 	};
 	const ToggleBinding = ({ keyName }: { keyName: string }) => (
-		<button className="text-[10px] text-[var(--text-secondary)] underline ml-2" onClick={() => clearBinding(keyName)}>Use manual</button>
+		<button className="text-[10px] text-[var(--text-secondary)] underline ml-2" onClick={() => {
+			updateFlow({
+				nodes: state.flow.nodes.map((n) => {
+					if (((n as any).data?.identifier?.id) !== nodeId) return n;
+					const prevAll = ((n as any).data?.variableBindingsByObject ?? {}) as Record<string, Record<string, { target?: string; boundResultNodeId?: string }>>;
+					const prev = { ...(prevAll[objectId] ?? {}) };
+					delete prev[keyName];
+					return { ...n, data: { ...(n as any).data, variableBindingsByObject: { ...prevAll, [objectId]: prev } } } as any;
+				})
+			});
+		}}>Use manual</button>
 	);
 
 	return (
@@ -328,8 +251,9 @@ function CanvasPerObjectProperties({ nodeId, objectId, assignments, onChange, on
 
 			<div className="grid grid-cols-2 gap-[var(--space-2)]">
 				<div>
-					<label className="block text-xs text-[var(--text-tertiary)]">Position X {initial.position?.x !== undefined ? <ConfiguredLabel /> : null} <BindingTag keyName="position" /> {bindButton('position')} <ToggleBinding keyName="position" /></label>
-					<NumberField label="" value={(initial.position?.x as number) ?? NaN} onChange={(x) => onChange({ position: { x, y: initial.position?.y ?? 0 } })} defaultValue={0} />
+					<label className="block text-xs text-[var(--text-tertiary)]">Position X {initial.position?.x !== undefined ? <ConfiguredLabel /> : null} <BindingTag keyName="position" /></label>
+					<NumberField label="" value={(initial.position?.x as number) ?? NaN} onChange={(x) => onChange({ position: { x, y: initial.position?.y ?? 0 } })} defaultValue={0} 
+						bindAdornment={<BindButton nodeId={nodeId} bindingKey="position" objectId={objectId} />} />
 				</div>
 				<div>
 					<label className="block text-xs text-[var(--text-tertiary)]">Position Y {initial.position?.y !== undefined ? <ConfiguredLabel /> : null}</label>
@@ -350,27 +274,32 @@ function CanvasPerObjectProperties({ nodeId, objectId, assignments, onChange, on
 
 			<div className="grid grid-cols-2 gap-[var(--space-2)]">
 				<div>
-					<label className="block text-xs text-[var(--text-tertiary)]">Rotation {initial.rotation !== undefined ? <ConfiguredLabel /> : null} <BindingTag keyName="rotation" /> {bindButton('rotation')} <ToggleBinding keyName="rotation" /></label>
-					<NumberField label="" value={(initial.rotation as number) ?? NaN} onChange={(rotation) => onChange({ rotation })} step={0.1} defaultValue={0} />
+					<label className="block text-xs text-[var(--text-tertiary)]">Rotation {initial.rotation !== undefined ? <ConfiguredLabel /> : null} <BindingTag keyName="rotation" /></label>
+					<NumberField label="" value={(initial.rotation as number) ?? NaN} onChange={(rotation) => onChange({ rotation })} step={0.1} defaultValue={0} 
+						bindAdornment={<BindButton nodeId={nodeId} bindingKey="rotation" objectId={objectId} />} />
 				</div>
 				<div>
-					<label className="block text-xs text-[var(--text-tertiary)]">Opacity {initial.opacity !== undefined ? <ConfiguredLabel /> : null} <BindingTag keyName="opacity" /> {bindButton('opacity')} <ToggleBinding keyName="opacity" /></label>
-					<NumberField label="" value={(initial.opacity as number) ?? NaN} onChange={(opacity) => onChange({ opacity })} min={0} max={1} step={0.05} defaultValue={1} />
+					<label className="block text-xs text-[var(--text-tertiary)]">Opacity {initial.opacity !== undefined ? <ConfiguredLabel /> : null} <BindingTag keyName="opacity" /></label>
+					<NumberField label="" value={(initial.opacity as number) ?? NaN} onChange={(opacity) => onChange({ opacity })} min={0} max={1} step={0.05} defaultValue={1} 
+						bindAdornment={<BindButton nodeId={nodeId} bindingKey="opacity" objectId={objectId} />} />
 				</div>
 			</div>
 
 			<div className="grid grid-cols-3 gap-[var(--space-2)] items-end">
 				<div>
-					<ColorField label="Fill" value={(initial.fillColor as string) ?? ''} onChange={(fillColor) => onChange({ fillColor })} />
-					<div className="text-[10px] mt-1">{bindButton('fillColor')} <ToggleBinding keyName="fillColor" /> <BindingTag keyName="fillColor" /></div>
+					<ColorField label="Fill" value={(initial.fillColor as string) ?? ''} onChange={(fillColor) => onChange({ fillColor })} 
+						bindAdornment={<BindButton nodeId={nodeId} bindingKey="fillColor" objectId={objectId} />} />
+					<div className="text-[10px] mt-1"><ToggleBinding keyName="fillColor" /> <BindingTag keyName="fillColor" /></div>
 				</div>
 				<div>
-					<ColorField label="Stroke" value={(initial.strokeColor as string) ?? ''} onChange={(strokeColor) => onChange({ strokeColor })} />
-					<div className="text-[10px] mt-1">{bindButton('strokeColor')} <ToggleBinding keyName="strokeColor" /> <BindingTag keyName="strokeColor" /></div>
+					<ColorField label="Stroke" value={(initial.strokeColor as string) ?? ''} onChange={(strokeColor) => onChange({ strokeColor })} 
+						bindAdornment={<BindButton nodeId={nodeId} bindingKey="strokeColor" objectId={objectId} />} />
+					<div className="text-[10px] mt-1"><ToggleBinding keyName="strokeColor" /> <BindingTag keyName="strokeColor" /></div>
 				</div>
 				<div>
-					<NumberField label="Stroke W" value={(initial.strokeWidth as number) ?? NaN} onChange={(strokeWidth) => onChange({ strokeWidth })} min={0} step={0.5} defaultValue={1} />
-					<div className="text-[10px] mt-1">{bindButton('strokeWidth')} <ToggleBinding keyName="strokeWidth" /> <BindingTag keyName="strokeWidth" /></div>
+					<NumberField label="Stroke W" value={(initial.strokeWidth as number) ?? NaN} onChange={(strokeWidth) => onChange({ strokeWidth })} min={0} step={0.5} defaultValue={1} 
+						bindAdornment={<BindButton nodeId={nodeId} bindingKey="strokeWidth" objectId={objectId} />} />
+					<div className="text-[10px] mt-1"><ToggleBinding keyName="strokeWidth" /> <BindingTag keyName="strokeWidth" /></div>
 				</div>
 			</div>
 		</div>

--- a/src/components/workspace/common/object-selection-panel.tsx
+++ b/src/components/workspace/common/object-selection-panel.tsx
@@ -12,7 +12,7 @@ interface ObjectSelectionPanelProps {
 
 export function ObjectSelectionPanel({ items, selectedId, onSelect, emptyLabel = 'No items', title = 'Objects' }: ObjectSelectionPanelProps) {
 	return (
-		<div className="w-[var(--sidebar-width)] border-r border-[var(--border-primary)] p-[var(--space-3)] bg-[var(--surface-1)]">
+		<div className="space-y-[var(--space-2)]">
 			<div className="text-xs text-[var(--text-tertiary)] mb-[var(--space-2)]">{title}</div>
 			<div className="space-y-[var(--space-2)] max-h-full overflow-y-auto bg-[var(--surface-2)] rounded-[var(--radius-sm)] p-[var(--space-3)]">
 				{items.length === 0 ? (

--- a/src/components/workspace/property-panel.tsx
+++ b/src/components/workspace/property-panel.tsx
@@ -20,6 +20,7 @@ import type {
 } from "@/shared/types/nodes";
 import type { PropertySchema } from "@/shared/types/properties";
 import type { PerObjectAssignments, ObjectAssignments } from '@/shared/properties/assignments';
+import { BindButton } from '@/components/workspace/binding/bindings';
 
 interface PropertyPanelProps {
   node: Node<NodeData>;
@@ -239,6 +240,10 @@ function SchemaBasedProperties({
       if (schema.key === 'colorValue' && data.valueType !== 'color') return null;
     }
 
+    // Only nodes that support variableBindings get the bind adornment (animation, canvas)
+    const supportsBinding = nodeType === 'animation' || nodeType === 'canvas';
+    const nodeId = (data as any)?.identifier?.id as string | undefined;
+
     switch (schema.type) {
       case 'number':
         return (
@@ -251,6 +256,7 @@ function SchemaBasedProperties({
             max={schema.max}
             step={schema.step}
             defaultValue={schema.defaultValue}
+            bindAdornment={supportsBinding && nodeId ? (<BindButton nodeId={nodeId} bindingKey={schema.key} />) : undefined}
           />
         );
 
@@ -261,6 +267,7 @@ function SchemaBasedProperties({
             label={schema.label}
             value={value as string}
             onChange={(newValue) => onChange({ [schema.key]: newValue } as Partial<NodeData>)}
+            bindAdornment={supportsBinding && nodeId ? (<BindButton nodeId={nodeId} bindingKey={schema.key} />) : undefined}
           />
         );
 
@@ -276,6 +283,7 @@ function SchemaBasedProperties({
               onChange({ [schema.key]: casted } as Partial<NodeData>);
             }}
             options={schema.options}
+            bindAdornment={supportsBinding && nodeId ? (<BindButton nodeId={nodeId} bindingKey={schema.key} />) : undefined}
           />
         );
 
@@ -292,6 +300,7 @@ function SchemaBasedProperties({
                 value={point.x}
                 onChange={(x) => onChange({ [schema.key]: { ...point, x } } as Partial<NodeData>)}
                 defaultValue={0}
+                bindAdornment={supportsBinding && nodeId ? (<BindButton nodeId={nodeId} bindingKey={schema.key} />) : undefined}
               />
               <NumberField
                 label="Y"

--- a/src/components/workspace/timeline-editor-core.test.tsx
+++ b/src/components/workspace/timeline-editor-core.test.tsx
@@ -2,6 +2,28 @@ import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { TimelineEditorCore } from './timeline-editor-core';
+import type { WorkspaceState, TimelineEditorData } from '@/types/workspace-state';
+import { WorkspaceContext } from './workspace-context';
+
+function TestWorkspaceProvider({ children }: { children: React.ReactNode }) {
+	const mockState: WorkspaceState = {
+		flow: { nodes: [], edges: [] },
+		editors: { timeline: {} as Record<string, TimelineEditorData> },
+		ui: { activeTab: 'timeline', selectedNodeId: 'n1', selectedNodeType: 'animation' }
+	};
+	const value = {
+		state: mockState,
+		updateFlow: vi.fn(),
+		updateTimeline: vi.fn(),
+		updateUI: vi.fn(),
+		saveNow: vi.fn(),
+		isSaving: false,
+		hasUnsavedChanges: false,
+		lastSaved: null,
+		hasBackup: false,
+	};
+	return <WorkspaceContext.Provider value={value}>{children}</WorkspaceContext.Provider>;
+}
 
 const baseTrack = {
   startTime: 0,
@@ -15,7 +37,11 @@ const baseTrack = {
 describe('TimelineEditorCore (controlled)', () => {
   it('calls onChange when duration edited', () => {
     const onChange = vi.fn();
-    render(<TimelineEditorCore animationNodeId="n1" duration={3} tracks={[baseTrack]} onChange={onChange} />);
+    render(
+      <TestWorkspaceProvider>
+        <TimelineEditorCore animationNodeId="n1" duration={3} tracks={[baseTrack]} onChange={onChange} />
+      </TestWorkspaceProvider>
+    );
     const input = screen.getByRole('spinbutton') as HTMLInputElement;
     input.focus();
     fireEvent.change(input, { target: { value: '4' } });

--- a/src/components/workspace/timeline-editor-core.tsx
+++ b/src/components/workspace/timeline-editor-core.tsx
@@ -26,6 +26,7 @@ import type { PerObjectAssignments, TrackOverride } from '@/shared/properties/as
 import { Link as LinkIcon } from "lucide-react";
 import { useWorkspace } from './workspace-context';
 import { FlowTracker } from '@/lib/flow/flow-tracking';
+import { BindButton } from '@/components/workspace/binding/bindings';
 
 function BindingTag({ nodeId, keyName, objectId }: { nodeId: string; keyName: string; objectId?: string }) {
   const { state } = useWorkspace();
@@ -553,22 +554,7 @@ function TrackProperties({ track, onChange, allTracks, onDisplayNameChange, vali
   const [showBindMenuFor, setShowBindMenuFor] = useState<string | null>(null);
 
   const bindButton = (fieldKey: string, onBind: (resultNodeId: string) => void) => (
-    <div className="relative">
-      <button type="button" onClick={() => setShowBindMenuFor(prev => prev === fieldKey ? null : fieldKey)} className="p-1 rounded hover:bg-[var(--surface-interactive)]" title="Bind to Result variable">
-        <LinkIcon size={14} />
-      </button>
-      {showBindMenuFor === fieldKey && (
-        <div className="absolute right-0 z-10 mt-1 bg-[var(--surface-2)] border border-[var(--border-primary)] rounded shadow-md min-w-[160px]">
-          {variables.length === 0 ? (
-            <div className="px-3 py-2 text-xs text-[var(--text-tertiary)]">No connected Result variables</div>
-          ) : variables.map(v => (
-            <div key={v.id} className="px-3 py-2 text-xs hover:bg-[var(--surface-interactive)] cursor-pointer" onClick={() => { onBind(v.id); setShowBindMenuFor(null); }}>
-              {v.name}
-            </div>
-          ))}
-        </div>
-      )}
-    </div>
+    <BindButton nodeId={animationNodeId} bindingKey={fieldKey} />
   );
 
   const clearBinding = (key: string) => {
@@ -777,6 +763,7 @@ function TrackProperties({ track, onChange, allTracks, onDisplayNameChange, vali
               { value: "fill", label: "Fill" },
               { value: "stroke", label: "Stroke" },
             ]}
+            bindAdornment={!override ? (<BindButton nodeId={animationNodeId} bindingKey={`color.property`} />) : undefined}
           />
           <div className="grid grid-cols-2 gap-[var(--space-2)]">
             <ColorField label="From Color" value={(override?.properties as any)?.from ?? track.properties.from} onChange={(from) => updateProperties({ from })} bindAdornment={!override ? bindButton(`color.from`, (rid) => writeBinding(`color.from`, rid)) : undefined} />

--- a/src/components/workspace/workspace-context.tsx
+++ b/src/components/workspace/workspace-context.tsx
@@ -22,7 +22,7 @@ interface WorkspaceContextValue {
   hasBackup: boolean;
 }
 
-const WorkspaceContext = createContext<WorkspaceContextValue | null>(null);
+export const WorkspaceContext = createContext<WorkspaceContextValue | null>(null);
 
 export function WorkspaceProvider({ children, workspaceId }: { children: ReactNode; workspaceId: string }) {
   const { toast } = useNotifications();


### PR DESCRIPTION
Unify and automate the bindable property UI across Canvas and Timeline editors for a consistent and scalable user experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-08d086c4-a8a4-45e1-9b97-68ec54e177d5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-08d086c4-a8a4-45e1-9b97-68ec54e177d5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

