### PR TITLE
Implement per-field override and binding logic

### DIFF
--- a/src/components/workspace/binding/bindings.tsx
+++ b/src/components/workspace/binding/bindings.tsx
@@ -78,6 +78,7 @@ export function BindButton({ nodeId, bindingKey, objectId, className }: BindButt
 	const [open, setOpen] = useState(false);
 	const boundId = getBinding(bindingKey);
 	const boundName = getBoundName(boundId);
+	const isBound = !!boundId;
 
 	return (
 		<div className={`relative ${className ?? ''}`}>
@@ -85,9 +86,10 @@ export function BindButton({ nodeId, bindingKey, objectId, className }: BindButt
 				type="button"
 				title={boundId ? `Bound to ${boundName ?? boundId}` : 'Bind to Result variable'}
 				onClick={() => setOpen(v => !v)}
-				className={`p-1 rounded hover:bg-[var(--surface-interactive)] ${boundId ? 'text-[var(--accent-500)]' : ''}`}
+				className={`relative p-1 rounded hover:bg-[var(--surface-interactive)] ${isBound ? 'text-[var(--accent-500)]' : ''}`}
 			>
 				<LinkIcon size={14} />
+				{isBound && <span className="absolute -top-1 -right-1 w-2 h-2 bg-[var(--accent-500)] rounded-full" />}
 			</button>
 			{open && (
 				<div className="absolute right-0 z-50 mt-1 bg-[var(--surface-2)] border border-[var(--border-primary)] rounded shadow-md min-w-[180px]">

--- a/src/components/workspace/property-panel.tsx
+++ b/src/components/workspace/property-panel.tsx
@@ -300,13 +300,14 @@ function SchemaBasedProperties({
                 value={point.x}
                 onChange={(x) => onChange({ [schema.key]: { ...point, x } } as Partial<NodeData>)}
                 defaultValue={0}
-                bindAdornment={supportsBinding && nodeId ? (<BindButton nodeId={nodeId} bindingKey={schema.key} />) : undefined}
+                bindAdornment={supportsBinding && nodeId ? (<BindButton nodeId={nodeId} bindingKey={`${schema.key}.x`} />) : undefined}
               />
               <NumberField
                 label="Y"
                 value={point.y}
                 onChange={(y) => onChange({ [schema.key]: { ...point, y } } as Partial<NodeData>)}
                 defaultValue={0}
+                bindAdornment={supportsBinding && nodeId ? (<BindButton nodeId={nodeId} bindingKey={`${schema.key}.y`} />) : undefined}
               />
             </div>
           </div>

--- a/src/components/workspace/timeline-editor-core.tsx
+++ b/src/components/workspace/timeline-editor-core.tsx
@@ -532,9 +532,11 @@ function TrackProperties({ track, onChange, allTracks, onDisplayNameChange, vali
   // Variable discovery uses animationNodeId to mirror object discovery behavior
   const { state, updateFlow } = useWorkspace();
 
-  const bindButton = (fieldKey: string) => (
-    <BindButton nodeId={animationNodeId} bindingKey={fieldKey} objectId={override ? selectedObjectId : undefined} />
-  );
+  const bindButton = (fieldKey: string) => {
+    // Prefer track-specific key when a track is selected
+    const specific = `track.${track.identifier.id}.${fieldKey}`;
+    return <BindButton nodeId={animationNodeId} bindingKey={specific} objectId={override ? selectedObjectId : undefined} />;
+  };
 
   const clearBinding = (key: string) => {
     updateFlow({
@@ -543,11 +545,13 @@ function TrackProperties({ track, onChange, allTracks, onDisplayNameChange, vali
         if (override && selectedObjectId) {
           const prevAll = ((n as any).data?.variableBindingsByObject ?? {}) as Record<string, Record<string, { target?: string; boundResultNodeId?: string }>>;
           const prev = { ...(prevAll[selectedObjectId] ?? {}) };
+          delete prev[`track.${track.identifier.id}.${key}`];
           delete prev[key];
           return { ...n, data: { ...(n as any).data, variableBindingsByObject: { ...prevAll, [selectedObjectId]: prev } } } as any;
         }
         const prev = ((n as any).data?.variableBindings ?? {}) as Record<string, { target?: string; boundResultNodeId?: string }>;
         const next = { ...prev } as typeof prev;
+        delete next[`track.${track.identifier.id}.${key}`];
         delete next[key];
         return { ...n, data: { ...(n as any).data, variableBindings: next } } as any;
       })
@@ -608,7 +612,7 @@ function TrackProperties({ track, onChange, allTracks, onDisplayNameChange, vali
               defaultValue={0}
               bindAdornment={bindButton(`move.from.x`)}
             />
-            <div className="text-[10px]"><ToggleBinding keyName="move.from.x" /> <BindingTag nodeId={animationNodeId} keyName="move.from.x" objectId={override ? selectedObjectId : undefined} /></div>
+            <div className="text-[10px]"><ToggleBinding keyName="move.from.x" /> <BindingTag nodeId={animationNodeId} keyName={`track.${track.identifier.id}.move.from.x`} objectId={override ? selectedObjectId : undefined} /></div>
             <NumberField
               label="From Y"
               value={(override?.properties as any)?.from?.y ?? track.properties.from.y}
@@ -616,7 +620,7 @@ function TrackProperties({ track, onChange, allTracks, onDisplayNameChange, vali
               defaultValue={0}
               bindAdornment={bindButton(`move.from.y`)}
             />
-            <div className="text-[10px]"><ToggleBinding keyName="move.from.y" /> <BindingTag nodeId={animationNodeId} keyName="move.from.y" objectId={override ? selectedObjectId : undefined} /></div>
+            <div className="text-[10px]"><ToggleBinding keyName="move.from.y" /> <BindingTag nodeId={animationNodeId} keyName={`track.${track.identifier.id}.move.from.y`} objectId={override ? selectedObjectId : undefined} /></div>
             <NumberField
               label="To X"
               value={(override?.properties as any)?.to?.x ?? track.properties.to.x}
@@ -624,7 +628,7 @@ function TrackProperties({ track, onChange, allTracks, onDisplayNameChange, vali
               defaultValue={100}
               bindAdornment={bindButton(`move.to.x`)}
             />
-            <div className="text-[10px]"><ToggleBinding keyName="move.to.x" /> <BindingTag nodeId={animationNodeId} keyName="move.to.x" objectId={override ? selectedObjectId : undefined} /></div>
+            <div className="text-[10px]"><ToggleBinding keyName="move.to.x" /> <BindingTag nodeId={animationNodeId} keyName={`track.${track.identifier.id}.move.to.x`} objectId={override ? selectedObjectId : undefined} /></div>
             <NumberField
               label="To Y"
               value={(override?.properties as any)?.to?.y ?? track.properties.to.y}
@@ -632,7 +636,7 @@ function TrackProperties({ track, onChange, allTracks, onDisplayNameChange, vali
               defaultValue={100}
               bindAdornment={bindButton(`move.to.y`)}
             />
-            <div className="text-[10px]"><ToggleBinding keyName="move.to.y" /> <BindingTag nodeId={animationNodeId} keyName="move.to.y" objectId={override ? selectedObjectId : undefined} /></div>
+            <div className="text-[10px]"><ToggleBinding keyName="move.to.y" /> <BindingTag nodeId={animationNodeId} keyName={`track.${track.identifier.id}.move.to.y`} objectId={override ? selectedObjectId : undefined} /></div>
           </div>
         </div>
       )}
@@ -649,7 +653,7 @@ function TrackProperties({ track, onChange, allTracks, onDisplayNameChange, vali
               defaultValue={0}
               bindAdornment={bindButton(`rotate.from`)}
             />
-            <div className="text-[10px]"><ToggleBinding keyName="rotate.from" /> <BindingTag nodeId={animationNodeId} keyName="rotate.from" objectId={override ? selectedObjectId : undefined} /></div>
+            <div className="text-[10px]"><ToggleBinding keyName="rotate.from" /> <BindingTag nodeId={animationNodeId} keyName={`track.${track.identifier.id}.rotate.from`} objectId={override ? selectedObjectId : undefined} /></div>
             <NumberField
               label="To Rotation"
               value={(override?.properties as any)?.to ?? track.properties.to}
@@ -658,7 +662,7 @@ function TrackProperties({ track, onChange, allTracks, onDisplayNameChange, vali
               defaultValue={1}
               bindAdornment={bindButton(`rotate.to`)}
             />
-            <div className="text-[10px]"><ToggleBinding keyName="rotate.to" /> <BindingTag nodeId={animationNodeId} keyName="rotate.to" objectId={override ? selectedObjectId : undefined} /></div>
+            <div className="text-[10px]"><ToggleBinding keyName="rotate.to" /> <BindingTag nodeId={animationNodeId} keyName={`track.${track.identifier.id}.rotate.to`} objectId={override ? selectedObjectId : undefined} /></div>
           </div>
         </div>
       )}
@@ -675,7 +679,7 @@ function TrackProperties({ track, onChange, allTracks, onDisplayNameChange, vali
               defaultValue={1}
               bindAdornment={bindButton(`scale.from`)}
             />
-            <div className="text-[10px]"><ToggleBinding keyName="scale.from" /> <BindingTag nodeId={animationNodeId} keyName="scale.from" objectId={override ? selectedObjectId : undefined} /></div>
+            <div className="text-[10px]"><ToggleBinding keyName="scale.from" /> <BindingTag nodeId={animationNodeId} keyName={`track.${track.identifier.id}.scale.from`} objectId={override ? selectedObjectId : undefined} /></div>
             <NumberField
               label="To"
               value={(override?.properties as any)?.to ?? track.properties.to}
@@ -684,7 +688,7 @@ function TrackProperties({ track, onChange, allTracks, onDisplayNameChange, vali
               defaultValue={2}
               bindAdornment={bindButton(`scale.to`)}
             />
-            <div className="text-[10px]"><ToggleBinding keyName="scale.to" /> <BindingTag nodeId={animationNodeId} keyName="scale.to" objectId={override ? selectedObjectId : undefined} /></div>
+            <div className="text-[10px]"><ToggleBinding keyName="scale.to" /> <BindingTag nodeId={animationNodeId} keyName={`track.${track.identifier.id}.scale.to`} objectId={override ? selectedObjectId : undefined} /></div>
           </div>
         </div>
       )}
@@ -701,7 +705,7 @@ function TrackProperties({ track, onChange, allTracks, onDisplayNameChange, vali
               defaultValue={1}
               bindAdornment={bindButton(`fade.from`)}
             />
-            <div className="text-[10px]"><ToggleBinding keyName="fade.from" /> <BindingTag nodeId={animationNodeId} keyName="fade.from" objectId={override ? selectedObjectId : undefined} /></div>
+            <div className="text-[10px]"><ToggleBinding keyName="fade.from" /> <BindingTag nodeId={animationNodeId} keyName={`track.${track.identifier.id}.fade.from`} objectId={override ? selectedObjectId : undefined} /></div>
             <NumberField
               label="To Opacity"
               value={(override?.properties as any)?.to ?? track.properties.to}
@@ -710,7 +714,7 @@ function TrackProperties({ track, onChange, allTracks, onDisplayNameChange, vali
               defaultValue={0}
               bindAdornment={bindButton(`fade.to`)}
             />
-            <div className="text-[10px]"><ToggleBinding keyName="fade.to" /> <BindingTag nodeId={animationNodeId} keyName="fade.to" objectId={override ? selectedObjectId : undefined} /></div>
+            <div className="text-[10px]"><ToggleBinding keyName="fade.to" /> <BindingTag nodeId={animationNodeId} keyName={`track.${track.identifier.id}.fade.to`} objectId={override ? selectedObjectId : undefined} /></div>
           </div>
         </div>
       )}
@@ -730,9 +734,9 @@ function TrackProperties({ track, onChange, allTracks, onDisplayNameChange, vali
           />
           <div className="grid grid-cols-2 gap-[var(--space-2)]">
             <ColorField label="From Color" value={(override?.properties as any)?.from ?? track.properties.from} onChange={(from) => updateProperties({ from })} bindAdornment={bindButton(`color.from`)} />
-            <div className="text-[10px]"><ToggleBinding keyName="color.from" /> <BindingTag nodeId={animationNodeId} keyName="color.from" objectId={override ? selectedObjectId : undefined} /></div>
+            <div className="text-[10px]"><ToggleBinding keyName="color.from" /> <BindingTag nodeId={animationNodeId} keyName={`track.${track.identifier.id}.color.from`} objectId={override ? selectedObjectId : undefined} /></div>
             <ColorField label="To Color" value={(override?.properties as any)?.to ?? track.properties.to} onChange={(to) => updateProperties({ to })} bindAdornment={bindButton(`color.to`)} />
-            <div className="text-[10px]"><ToggleBinding keyName="color.to" /> <BindingTag nodeId={animationNodeId} keyName="color.to" objectId={override ? selectedObjectId : undefined} /></div>
+            <div className="text-[10px]"><ToggleBinding keyName="color.to" /> <BindingTag nodeId={animationNodeId} keyName={`track.${track.identifier.id}.color.to`} objectId={override ? selectedObjectId : undefined} /></div>
           </div>
         </div>
       )}

--- a/src/server/animation-processing/scene/scene-assembler.ts
+++ b/src/server/animation-processing/scene/scene-assembler.ts
@@ -189,8 +189,11 @@ export function convertTracksToSceneAnimations(
     // 2. End value from previous track of same type in the same sequence
     // 3. End value from prior animations for this object
     // 4. Default 'from' value
-    const hasExplicitFrom = Object.prototype.hasOwnProperty.call(baseTrack.properties ?? {}, 'from');
-    if (!hasExplicitFrom && (properties.from === undefined || isDefaultFrom(baseTrack.type, properties.from))) {
+    // Explicit only when the field is truly overridden (manual per-field override or non-default value)
+    const fromExplicitByOverride = !!(matchedOverride && Object.prototype.hasOwnProperty.call(matchedOverride.properties ?? {}, 'from'));
+    const fromIsNonDefault = !isDefaultFrom(baseTrack.type, (baseTrack as any)?.properties?.from);
+    const isFromExplicit = fromExplicitByOverride || fromIsNonDefault;
+    if (!isFromExplicit && (properties.from === undefined || isDefaultFrom(baseTrack.type, properties.from))) {
       // Try to get from the same sequence first
       let inherited = getEndValueFromSameSequence(baseTrack, sortedTracks, targetProperty);
       


### PR DESCRIPTION
Enable per-field binding and override for properties in canvas and timeline, ensuring granular control and proper chaining of related values.

This resolves an issue where binding or overriding a specific field (e.g., `rotate.to`) would inadvertently lock related fields (e.g., `rotate.from`), preventing them from inheriting or chaining. Now, only the targeted field is affected, allowing other fields to update dynamically. This also introduces per-axis binding for 2D point properties and enhances visual feedback for bound fields.

---
<a href="https://cursor.com/background-agent?bcId=bc-ce691abb-c821-4ae4-8d08-ecf53b1982ab">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ce691abb-c821-4ae4-8d08-ecf53b1982ab">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

