### PR TITLE
Unify override and binding reset mechanisms

### DIFF
--- a/src/components/workspace/binding/bindings.tsx
+++ b/src/components/workspace/binding/bindings.tsx
@@ -2,6 +2,10 @@ import React, { useMemo, useState } from 'react';
 import { Link as LinkIcon } from 'lucide-react';
 import { useWorkspace } from '@/components/workspace/workspace-context';
 import { FlowTracker } from '@/lib/flow/flow-tracking';
+import { deleteByPath } from '@/shared/utils/object-path';
+import { transformFactory } from '@/shared/registry/transforms';
+import type { AnimationTrack, NodeData } from '@/shared/types/nodes';
+import type { PerObjectAssignments, ObjectAssignments, TrackOverride } from '@/shared/properties/assignments';
 
 interface BindButtonProps {
 	nodeId: string;
@@ -70,11 +74,150 @@ function useVariableBinding(nodeId: string, objectId?: string) {
 		});
 	};
 
-	return { variables, getBinding, getBoundName, bind, clear } as const;
+	// Unified reset: clear binding and associated manual overrides, falling back to defaults
+	const resetToDefault = (rawKey: string) => {
+		updateFlow({
+			nodes: state.flow.nodes.map((n) => {
+				const data = (n as any).data as NodeData | undefined;
+				if (!data || data.identifier?.id !== nodeId) return n;
+
+				const nextData: any = { ...data };
+
+				// 1) Clear binding for this key (supports per-object and global)
+				if (objectId) {
+					const all = { ...(nextData.variableBindingsByObject ?? {}) } as Record<string, Record<string, { target?: string; boundResultNodeId?: string }>>;
+					const obj = { ...(all[objectId] ?? {}) };
+					delete obj[rawKey];
+					all[objectId] = obj;
+					nextData.variableBindingsByObject = all;
+				} else {
+					const vb = { ...(nextData.variableBindings ?? {}) } as Record<string, { target?: string; boundResultNodeId?: string }>;
+					delete vb[rawKey];
+					nextData.variableBindings = vb;
+				}
+
+				// Helper: prune empty nested objects
+				const pruneEmpty = (obj: any) => {
+					if (!obj || typeof obj !== 'object') return obj;
+					for (const k of Object.keys(obj)) {
+						if (obj[k] && typeof obj[k] === 'object') pruneEmpty(obj[k]);
+						if (obj[k] && typeof obj[k] === 'object' && Object.keys(obj[k]).length === 0) delete obj[k];
+					}
+					return obj;
+				};
+
+				// 2) Clear manual overrides
+				// Canvas node: per-object overrides live in perObjectAssignments[objectId].initial
+				if (data.type === 'canvas') {
+					const key = rawKey; // e.g., 'position.x', 'fillColor'
+					if (objectId) {
+						const poa = { ...(nextData.perObjectAssignments as PerObjectAssignments ?? {}) };
+						const entry: ObjectAssignments = { ...(poa[objectId] ?? {}) } as ObjectAssignments;
+						const initial = { ...(entry.initial ?? {}) } as Record<string, unknown>;
+						deleteByPath(initial as Record<string, unknown>, key);
+						const prunedInitial = pruneEmpty(initial);
+						if (Object.keys(prunedInitial).length === 0) delete (entry as any).initial; else (entry as any).initial = prunedInitial;
+						if ((entry.initial === undefined) && (!entry.tracks || entry.tracks.length === 0)) {
+							delete poa[objectId];
+						} else {
+							poa[objectId] = entry;
+						}
+						nextData.perObjectAssignments = poa;
+					} else {
+						// Node-level canvas defaults stored directly on node data
+						deleteByPath(nextData as unknown as Record<string, unknown>, key);
+					}
+				} else if (data.type === 'animation') {
+					// Animation node: per-object track overrides or global track defaults
+					const trackPrefix = 'track.';
+					if (rawKey.startsWith(trackPrefix)) {
+						// track.<id>.<subPath>
+						const [, trackId, ...rest] = rawKey.split('.');
+						const subPath = rest.join('.'); // e.g., 'move.from.x' or 'easing' etc.
+						const poa = { ...(nextData.perObjectAssignments as PerObjectAssignments ?? {}) };
+						if (!objectId) return { ...n, data: nextData } as any;
+						const entry: ObjectAssignments = { ...(poa[objectId] ?? {}) } as ObjectAssignments;
+						const tracks: TrackOverride[] = Array.isArray(entry.tracks) ? [...entry.tracks] : [];
+						const idx = tracks.findIndex(t => t.trackId === trackId);
+						if (idx >= 0) {
+							const t = { ...tracks[idx] } as TrackOverride;
+							const props = { ...(t.properties ?? {}) } as Record<string, unknown>;
+							// Strip type prefix if present (e.g., 'move.from.x' -> 'from.x')
+							const dot = subPath.indexOf('.');
+							const propPath = dot >= 0 ? subPath.slice(dot + 1) : subPath;
+							deleteByPath(props as Record<string, unknown>, propPath);
+							const prunedProps = pruneEmpty(props);
+							if (Object.keys(prunedProps).length === 0) delete (t as any).properties; else (t as any).properties = prunedProps;
+							// Also allow clearing scalar timing/easing keys
+							if (propPath === 'easing' || propPath === 'duration' || propPath === 'startTime') delete (t as any)[propPath];
+							const hasProps = !!t.properties && Object.keys(t.properties as Record<string, unknown>).length > 0;
+							const hasMeta = (t as any).easing !== undefined || (t as any).startTime !== undefined || (t as any).duration !== undefined;
+							if (!hasProps && !hasMeta) tracks.splice(idx, 1); else tracks[idx] = t;
+							(entry as any).tracks = tracks;
+							if ((!entry.initial || Object.keys(entry.initial as any).length === 0) && (!tracks || tracks.length === 0)) {
+								delete poa[objectId];
+							} else {
+								poa[objectId] = entry;
+							}
+							nextData.perObjectAssignments = poa;
+						}
+					} else {
+						// Global track defaults: reset the base track properties in timeline editor data
+						// subPath like 'duration' or '<type>.<prop>...'
+						const subPath = rawKey;
+						const tracks: AnimationTrack[] = Array.isArray((nextData as any).tracks) ? ([...(nextData as any).tracks] as AnimationTrack[]) : [];
+						const dot = subPath.indexOf('.');
+						if (subPath === 'duration') {
+							(nextData as any).duration = (transformFactory.getTransformDefinition ? undefined : undefined); // duration default handled elsewhere; keep editor state owner to reset via timeline flow
+						} else if (dot >= 0) {
+							const type = subPath.slice(0, dot);
+							const propPath = subPath.slice(dot + 1);
+							const defaults = transformFactory.getDefaultProperties(type) ?? {};
+							const getDefaultByPath = (obj: any, path: string): any => {
+								const parts = path.split('.');
+								let cur = obj;
+								for (const p of parts) {
+									if (!cur || typeof cur !== 'object') return undefined;
+									cur = cur[p];
+								}
+								return cur;
+							};
+							const defaultVal = getDefaultByPath(defaults, propPath);
+							(nextData as any).tracks = tracks.map((t) => {
+								if ((t as any).type !== type) return t;
+								const copy = { ...(t as any), properties: { ...(t as any).properties } };
+								if (defaultVal === undefined) {
+									deleteByPath(copy.properties as Record<string, unknown>, propPath);
+								} else {
+									// set to default
+									const assignByPath = (obj: any, path: string, val: any) => {
+										const parts = path.split('.');
+										let cursor = obj;
+										for (let i = 0; i < parts.length - 1; i++) {
+											const k = parts[i]!;
+											if (!cursor[k] || typeof cursor[k] !== 'object') cursor[k] = {};
+											cursor = cursor[k];
+										}
+										cursor[parts[parts.length - 1]!] = val;
+									};
+									assignByPath(copy.properties, propPath, defaultVal);
+								}
+								return copy as AnimationTrack;
+							});
+						}
+					}
+				}
+
+				return { ...n, data: nextData } as any;
+			})
+		});
+	};
+
+	return { variables, getBinding, getBoundName, bind, clear, resetToDefault } as const;
 }
 
 export function BindButton({ nodeId, bindingKey, objectId, className }: BindButtonProps) {
-	const { variables, getBinding, getBoundName, bind, clear } = useVariableBinding(nodeId, objectId);
+	const { variables, getBinding, getBoundName, bind, clear, resetToDefault } = useVariableBinding(nodeId, objectId);
 	const [open, setOpen] = useState(false);
 	const boundId = getBinding(bindingKey);
 	const boundName = getBoundName(boundId);
@@ -117,10 +260,16 @@ export function BindButton({ nodeId, bindingKey, objectId, className }: BindButt
 							>
 								Clear binding
 							</div>
-						</>
-					)}
-				</div>
-			)}
-		</div>
-	);
-}
+						<div
+							className="px-3 py-2 text-xs text-[var(--text-primary)] hover:bg-[var(--surface-interactive)] cursor-pointer"
+							onClick={() => { resetToDefault(bindingKey); setOpen(false); }}
+						>
+							Reset to default
+						</div>
+ 						</>
+ 					)}
+ 				</div>
+ 			)}
+ 		</div>
+ 	);
+ }

--- a/src/components/workspace/canvas-editor-tab.tsx
+++ b/src/components/workspace/canvas-editor-tab.tsx
@@ -296,19 +296,7 @@ function CanvasPerObjectProperties({ nodeId, objectId, assignments, onChange, on
 		const isBound = !!vbAll?.[objectId]?.[key]?.boundResultNodeId;
 		return (isBound || isOverridden(key)) ? `${baseLabel} (override)` : baseLabel;
 	};
-	const ToggleBinding = ({ keyName }: { keyName: string }) => (
-		<button className="text-[10px] text-[var(--text-secondary)] underline ml-2" onClick={() => {
-			updateFlow({
-				nodes: state.flow.nodes.map((n) => {
-					if (((n as any).data?.identifier?.id) !== nodeId) return n;
-					const prevAll = ((n as any).data?.variableBindingsByObject ?? {}) as Record<string, Record<string, { target?: string; boundResultNodeId?: string }>>;
-					const prev = { ...(prevAll[objectId] ?? {}) };
-					delete prev[keyName];
-					return { ...n, data: { ...(n as any).data, variableBindingsByObject: { ...prevAll, [objectId]: prev } } } as any;
-				})
-			});
-		}}>Use manual</button>
-	);
+	// Legacy ToggleBinding UI removed in favor of centralized reset in Bind menu
 
 	return (
 		<div className="space-y-[var(--space-3)]">
@@ -355,17 +343,17 @@ function CanvasPerObjectProperties({ nodeId, objectId, assignments, onChange, on
 				<div>
 					<ColorField label={labelWithOverride("Fill", "fillColor")} value={(initial.fillColor as string) ?? (base.fillColor as string) ?? ''} onChange={(fillColor) => onChange({ fillColor })} 
 						bindAdornment={<BindButton nodeId={nodeId} bindingKey="fillColor" objectId={objectId} />} />
-					<div className="text-[10px] mt-1"><ToggleBinding keyName="fillColor" /> <BindingTag keyName="fillColor" /></div>
+					<div className="text-[10px] mt-1"><BindingTag keyName="fillColor" /></div>
 				</div>
 				<div>
 					<ColorField label={labelWithOverride("Stroke", "strokeColor")} value={(initial.strokeColor as string) ?? (base.strokeColor as string) ?? ''} onChange={(strokeColor) => onChange({ strokeColor })} 
 						bindAdornment={<BindButton nodeId={nodeId} bindingKey="strokeColor" objectId={objectId} />} />
-					<div className="text-[10px] mt-1"><ToggleBinding keyName="strokeColor" /> <BindingTag keyName="strokeColor" /></div>
+					<div className="text-[10px] mt-1"><BindingTag keyName="strokeColor" /></div>
 				</div>
 				<div>
 					<NumberField label={labelWithOverride("Stroke W", "strokeWidth")} value={(initial.strokeWidth as number) ?? (base.strokeWidth as number) ?? 1} onChange={(strokeWidth) => onChange({ strokeWidth })} min={0} step={0.5} defaultValue={1} 
 						bindAdornment={<BindButton nodeId={nodeId} bindingKey="strokeWidth" objectId={objectId} />} />
-					<div className="text-[10px] mt-1"><ToggleBinding keyName="strokeWidth" /> <BindingTag keyName="strokeWidth" /></div>
+					<div className="text-[10px] mt-1"><BindingTag keyName="strokeWidth" /></div>
 				</div>
 			</div>
 		</div>

--- a/src/components/workspace/timeline-editor-core.tsx
+++ b/src/components/workspace/timeline-editor-core.tsx
@@ -570,9 +570,7 @@ export function TrackProperties({ track, onChange, allTracks, onDisplayNameChang
     });
   };
 
-  const ToggleBinding = ({ keyName }: { keyName: string }) => (
-    <Button variant="ghost" size="xs" className="underline ml-2" onClick={() => clearBinding(keyName)}>Use manual</Button>
-  );
+  // Legacy ToggleBinding UI removed in favor of centralized reset in Bind menu
 
   const handleSaveDisplayName = () => {
     const success = onDisplayNameChange(track.identifier.id, tempDisplayName);
@@ -691,8 +689,8 @@ export function TrackProperties({ track, onChange, allTracks, onDisplayNameChang
               />
             </div>
             <div className="grid grid-cols-2 gap-[var(--space-2)] text-[10px] text-[var(--text-tertiary)]">
-              <div><ToggleBinding keyName="move.from.x" /> <BindingTag nodeId={animationNodeId} keyName={`track.${track.identifier.id}.move.from.x`} objectId={selectedObjectId} /></div>
-              <div><ToggleBinding keyName="move.from.y" /> <BindingTag nodeId={animationNodeId} keyName={`track.${track.identifier.id}.move.from.y`} objectId={selectedObjectId} /></div>
+              <div><BindingTag nodeId={animationNodeId} keyName={`track.${track.identifier.id}.move.from.x`} objectId={selectedObjectId} /></div>
+              <div><BindingTag nodeId={animationNodeId} keyName={`track.${track.identifier.id}.move.from.y`} objectId={selectedObjectId} /></div>
             </div>
           </div>
 
@@ -716,8 +714,8 @@ export function TrackProperties({ track, onChange, allTracks, onDisplayNameChang
               />
             </div>
             <div className="grid grid-cols-2 gap-[var(--space-2)] text-[10px] text-[var(--text-tertiary)]">
-              <div><ToggleBinding keyName="move.to.x" /> <BindingTag nodeId={animationNodeId} keyName={`track.${track.identifier.id}.move.to.x`} objectId={selectedObjectId} /></div>
-              <div><ToggleBinding keyName="move.to.y" /> <BindingTag nodeId={animationNodeId} keyName={`track.${track.identifier.id}.move.to.y`} objectId={selectedObjectId} /></div>
+              <div><BindingTag nodeId={animationNodeId} keyName={`track.${track.identifier.id}.move.to.x`} objectId={selectedObjectId} /></div>
+              <div><BindingTag nodeId={animationNodeId} keyName={`track.${track.identifier.id}.move.to.y`} objectId={selectedObjectId} /></div>
             </div>
           </div>
         </div>
@@ -745,8 +743,8 @@ export function TrackProperties({ track, onChange, allTracks, onDisplayNameChang
             />
           </div>
           <div className="grid grid-cols-2 gap-[var(--space-2)] text-[10px] text-[var(--text-tertiary)]">
-            <div><ToggleBinding keyName="rotate.from" /> <BindingTag nodeId={animationNodeId} keyName={`track.${track.identifier.id}.rotate.from`} objectId={selectedObjectId} /></div>
-            <div><ToggleBinding keyName="rotate.to" /> <BindingTag nodeId={animationNodeId} keyName={`track.${track.identifier.id}.rotate.to`} objectId={selectedObjectId} /></div>
+            <div><BindingTag nodeId={animationNodeId} keyName={`track.${track.identifier.id}.rotate.from`} objectId={selectedObjectId} /></div>
+            <div><BindingTag nodeId={animationNodeId} keyName={`track.${track.identifier.id}.rotate.to`} objectId={selectedObjectId} /></div>
           </div>
         </div>
       )}
@@ -773,8 +771,8 @@ export function TrackProperties({ track, onChange, allTracks, onDisplayNameChang
             />
           </div>
           <div className="grid grid-cols-2 gap-[var(--space-2)] text-[10px] text-[var(--text-tertiary)]">
-            <div><ToggleBinding keyName="scale.from" /> <BindingTag nodeId={animationNodeId} keyName={`track.${track.identifier.id}.scale.from`} objectId={selectedObjectId} /></div>
-            <div><ToggleBinding keyName="scale.to" /> <BindingTag nodeId={animationNodeId} keyName={`track.${track.identifier.id}.scale.to`} objectId={selectedObjectId} /></div>
+            <div><BindingTag nodeId={animationNodeId} keyName={`track.${track.identifier.id}.scale.from`} objectId={selectedObjectId} /></div>
+            <div><BindingTag nodeId={animationNodeId} keyName={`track.${track.identifier.id}.scale.to`} objectId={selectedObjectId} /></div>
           </div>
         </div>
       )}
@@ -801,8 +799,8 @@ export function TrackProperties({ track, onChange, allTracks, onDisplayNameChang
             />
           </div>
           <div className="grid grid-cols-2 gap-[var(--space-2)] text-[10px] text-[var(--text-tertiary)]">
-            <div><ToggleBinding keyName="fade.from" /> <BindingTag nodeId={animationNodeId} keyName={`track.${track.identifier.id}.fade.from`} objectId={selectedObjectId} /></div>
-            <div><ToggleBinding keyName="fade.to" /> <BindingTag nodeId={animationNodeId} keyName={`track.${track.identifier.id}.fade.to`} objectId={selectedObjectId} /></div>
+            <div><BindingTag nodeId={animationNodeId} keyName={`track.${track.identifier.id}.fade.from`} objectId={selectedObjectId} /></div>
+            <div><BindingTag nodeId={animationNodeId} keyName={`track.${track.identifier.id}.fade.to`} objectId={selectedObjectId} /></div>
           </div>
         </div>
       )}
@@ -841,8 +839,8 @@ export function TrackProperties({ track, onChange, allTracks, onDisplayNameChang
               />
             </div>
             <div className="grid grid-cols-2 gap-[var(--space-2)] text-[10px] text-[var(--text-tertiary)]">
-              <div><ToggleBinding keyName="color.from" /> <BindingTag nodeId={animationNodeId} keyName={`track.${track.identifier.id}.color.from`} objectId={selectedObjectId} /></div>
-              <div><ToggleBinding keyName="color.to" /> <BindingTag nodeId={animationNodeId} keyName={`track.${track.identifier.id}.color.to`} objectId={selectedObjectId} /></div>
+              <div><BindingTag nodeId={animationNodeId} keyName={`track.${track.identifier.id}.color.from`} objectId={selectedObjectId} /></div>
+              <div><BindingTag nodeId={animationNodeId} keyName={`track.${track.identifier.id}.color.to`} objectId={selectedObjectId} /></div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Unifies property reset by removing scattered "Use manual" buttons and centralizing "Reset to default" in the Bind menu, which now clears both bindings and manual overrides.

---
<a href="https://cursor.com/background-agent?bcId=bc-10b9dab9-9e2e-43a5-9d29-289f9e021d64">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-10b9dab9-9e2e-43a5-9d29-289f9e021d64">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

