### PR TITLE
Implement batch rendering for node-based tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,3 +132,11 @@ Additionally, for client notifications, ensure the custom channel exists (no sch
 
 - Enqueue via `renderQueue.enqueueOnly({ scene, config, userId, jobId })`.
 - Clients can wait for completion with the existing `waitForRenderJobEvent` helper.
+
+## Batch Rendering (v1)
+
+- Use the `Batch` node (Logic) to tag objects with a `key` (bindable).
+- Scene renders one video per unique key; non-batched objects appear in all outputs.
+- Deterministic order (keys sorted); runtime IDs are namespaced as `baseId@key`.
+- Filenames are `{key}.mp4` (sanitized); no templating in v1.
+- Overrides precedence unchanged for bound fields. Manual per-key overrides UI planned.

--- a/src/IMPLEMENTATION_SUMMARY.md
+++ b/src/IMPLEMENTATION_SUMMARY.md
@@ -1,0 +1,10 @@
+
+## Batch Rendering v1 (Batchion)
+
+- Batch node: logic category, input/output `object_stream`, property `key` (bindable).
+- Behavior: tags objects with `batch=true` and `batchKey` (no duplication or visual changes).
+- Validation: empty/whitespace key errors at execution with offending object IDs.
+- Metadata propagation: `SceneObject` carries `batch` and `batchKey`; downstream nodes pass through.
+- Scene executor: partitions by unique keys; renders each key with non-batched + matching objects; keys sorted; runtime IDs namespaced `baseId@key`.
+- Filenames: `{key}.mp4` (sanitized); storage provider supports `outputBasename` and `outputSubdir`.
+- Precedence: bindings remain authoritative; batch overrides UI deferred for v1 runtime; future-compatible.

--- a/src/components/workspace/nodes/batch-node.tsx
+++ b/src/components/workspace/nodes/batch-node.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import React from "react";
+import type { Node } from "reactflow";
+import type { NodeData } from "@/shared/types/nodes";
+import { useWorkspace } from "@/components/workspace/workspace-context";
+import { Input } from "@/components/ui/input";
+import { BindButton } from "@/components/workspace/binding/bindings";
+
+export function BatchNode({ id }: { id: string }) {
+  const { state, updateFlow } = useWorkspace();
+  const node = state.flow.nodes.find((n) => n.id === id) as
+    | Node<NodeData>
+    | undefined;
+  const nodeId = node?.data?.identifier?.id ?? id;
+
+  const data = (node?.data ?? {}) as unknown as Record<string, unknown> & {
+    key?: string;
+    variableBindings?: Record<string, { boundResultNodeId?: string }>;
+  };
+  const keyVal = typeof data.key === "string" ? data.key : "";
+  const isBound = Boolean(data.variableBindings?.key?.boundResultNodeId);
+
+  return (
+    <div className="min-w-[220px] rounded-md border border-[var(--border-primary)] bg-[var(--surface-1)] p-3 text-[var(--text-primary)]">
+      <div className="mb-2 font-medium">Batch</div>
+      <div className="space-y-2">
+        <div className="text-xs text-[var(--text-secondary)]">Key</div>
+        <Input
+          value={keyVal}
+          onChange={(e) => {
+            const next = e.target.value;
+            updateFlow({
+              nodes: state.flow.nodes.map((n) =>
+                n.id !== id ? n : { ...n, data: { ...n.data, key: next } },
+              ),
+            });
+          }}
+          disabled={isBound}
+          endAdornment={<BindButton nodeId={nodeId} bindingKey="key" />}
+        />
+        {isBound ? (
+          <div className="text-[10px] text-[var(--text-tertiary)]">
+            Bound (overrides disabled)
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/workspace/nodes/generated-mappings.ts
+++ b/src/components/workspace/nodes/generated-mappings.ts
@@ -23,6 +23,7 @@ import { ImageNode } from "./image-node";
 import { TextNode } from "./text-node";
 import { TypographyNode } from "./typography-node";
 import { MediaNode } from "./media-node";
+import { BatchNode } from "./batch-node";
 
 export const COMPONENT_MAPPING = {
   triangle: TriangleNode,
@@ -46,6 +47,7 @@ export const COMPONENT_MAPPING = {
   text: TextNode,
   typography: TypographyNode,
   media: MediaNode,
+  batch: BatchNode,
 } as const;
 
 export type ComponentMapping = typeof COMPONENT_MAPPING;

--- a/src/components/workspace/nodes/index.ts
+++ b/src/components/workspace/nodes/index.ts
@@ -19,3 +19,4 @@ export { MathOpNode } from "./math-op-node";
 export { DuplicateNode } from "./duplicate-node";
 export { ImageNode } from "./image-node";
 export { MediaNode } from "./media-node";
+export { BatchNode } from "./batch-node";

--- a/src/server/animation-processing/executors/logic-executor.test.ts
+++ b/src/server/animation-processing/executors/logic-executor.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { LogicNodeExecutor } from "./logic-executor";
+import { createExecutionContext, setNodeOutput } from "../execution-context";
+
+function makeNode(type: string, id: string, data: Record<string, unknown> = {}) {
+  return {
+    type,
+    data: { identifier: { id, displayName: id, type }, ...data },
+  } as any;
+}
+
+describe("Batch node", () => {
+  it("tags objects with batch metadata and errors on empty key", async () => {
+    const ex = new (LogicNodeExecutor as any)() as LogicNodeExecutor;
+    // @ts-ignore - access protected
+    ex.registerHandlers();
+
+    const ctx = createExecutionContext();
+    // Upstream object
+    setNodeOutput(ctx, "up", "output", "object_stream", [
+      { id: "o1", type: "rectangle", properties: { width: 5, height: 5 }, initialPosition: { x: 0, y: 0 } },
+    ]);
+
+    const node = makeNode("batch", "batch1", { key: "SKU123" });
+    const edges = [
+      { source: "up", sourceHandle: "output", target: "batch1", targetHandle: "input" },
+    ] as any;
+
+    await (ex as any).executeBatch(node, ctx, edges);
+    const out = ctx.nodeOutputs.get("batch1.output");
+    expect(out?.type).toBe("object_stream");
+    const items = out?.data as any[];
+    expect(items[0].batch).toBe(true);
+    expect(items[0].batchKey).toBe("SKU123");
+
+    // Empty key errors
+    const node2 = makeNode("batch", "batch2", { key: "  " });
+    const edges2 = [
+      { source: "up", sourceHandle: "output", target: "batch2", targetHandle: "input" },
+    ] as any;
+    await expect((ex as any).executeBatch(node2, ctx, edges2)).rejects.toThrow(
+      /Batch key resolved empty/,
+    );
+  });
+});
+

--- a/src/server/animation-processing/scene/scene-partitioner.test.ts
+++ b/src/server/animation-processing/scene/scene-partitioner.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import type { SceneObject } from "@/shared/types/scene";
+import { partitionByBatchKey } from "./scene-partitioner";
+
+function so(id: string, batch?: string): SceneObject {
+  return {
+    id,
+    type: "rectangle",
+    properties: { width: 10, height: 10 },
+    initialPosition: { x: 0, y: 0 },
+    ...(batch ? { batch: true, batchKey: batch } : {}),
+  } as unknown as SceneObject;
+}
+
+describe("partitionByBatchKey", () => {
+  it("returns single partition when no batched objects", () => {
+    const base = {
+      sceneNode: { data: { identifier: { id: "scene1" } } } as any,
+      objects: [so("a"), so("b")],
+      animations: [],
+    };
+    const out = partitionByBatchKey(base as any);
+    expect(out).toHaveLength(1);
+    expect(out[0].batchKey).toBeNull();
+    expect(out[0].objects.map((o) => o.id)).toEqual(["a", "b"]);
+  });
+
+  it("creates per-key partitions with sorted keys and includes non-batched in each", () => {
+    const base = {
+      sceneNode: { data: { identifier: { id: "scene1" } } } as any,
+      objects: [so("n1"), so("x", "B"), so("y", "A")],
+      animations: [],
+    };
+    const out = partitionByBatchKey(base as any);
+    expect(out).toHaveLength(2);
+    expect(out[0].batchKey).toBe("A");
+    expect(out[1].batchKey).toBe("B");
+    expect(out[0].objects.map((o) => o.id).sort()).toEqual(["n1", "y"].sort());
+    expect(out[1].objects.map((o) => o.id).sort()).toEqual(["n1", "x"].sort());
+  });
+});
+

--- a/src/server/rendering/canvas-renderer.ts
+++ b/src/server/rendering/canvas-renderer.ts
@@ -52,7 +52,10 @@ export class CanvasRenderer implements Renderer {
     const sceneRenderer = new SceneRenderer(scene, sceneRenderConfig);
     const frameGenerator = new FrameGenerator(frameConfig, linear);
 
-    const prepared = await this.storageProvider.prepareTarget("mp4");
+    const prepared = await this.storageProvider.prepareTarget("mp4", {
+      basename: config.outputBasename,
+      subdir: config.outputSubdir,
+    });
 
     try {
       await frameGenerator.generateAnimation(

--- a/src/server/rendering/renderer.ts
+++ b/src/server/rendering/renderer.ts
@@ -8,6 +8,9 @@ export interface SceneAnimationConfig {
   backgroundColor: string;
   videoPreset: string;
   videoCrf: number;
+  // Optional output hints (v1 batching)
+  outputBasename?: string; // e.g., key
+  outputSubdir?: string; // e.g., scene id for isolation
 }
 
 export const DEFAULT_SCENE_CONFIG: SceneAnimationConfig = {

--- a/src/shared/types/definitions.ts
+++ b/src/shared/types/definitions.ts
@@ -905,6 +905,41 @@ export const NODE_DEFINITIONS = {
     },
   },
 
+  batch: {
+    type: "batch",
+    label: "Batch",
+    description:
+      "Tags objects for batch rendering using a key. Does not duplicate or alter visuals.",
+    execution: {
+      category: "logic",
+      executor: "logic",
+    },
+    ports: {
+      inputs: [{ id: "input", type: "object_stream", label: "Objects" }],
+      outputs: [{ id: "output", type: "object_stream", label: "Tagged" }],
+    },
+    properties: {
+      properties: [
+        {
+          key: "key",
+          type: "string",
+          label: "Key",
+          defaultValue: "",
+        },
+      ],
+    },
+    rendering: {
+      icon: "🏷️",
+      colors: {
+        primary: "bg-[var(--node-logic)]",
+        handle: "!bg-[var(--node-logic)]",
+      },
+    },
+    defaults: {
+      key: "",
+    },
+  },
+
   image: {
     type: "image",
     label: "Image",

--- a/src/shared/types/scene.ts
+++ b/src/shared/types/scene.ts
@@ -20,6 +20,9 @@ export interface SceneObject {
   initialRotation?: number;
   initialScale?: Point2D;
   initialOpacity?: number;
+  // Batch metadata (propagates through object_stream unmodified)
+  batch?: boolean;
+  batchKey?: string;
   // ✅ ADD - Following existing pattern
   initialFillColor?: string;
   initialStrokeColor?: string;


### PR DESCRIPTION
Adds minimal batch rendering to enable "N items → N videos" from a single template, by introducing a `Batch` node and per-key scene iteration.

---
<a href="https://cursor.com/background-agent?bcId=bc-f6365cff-430b-4374-babe-0ffdab5f1dbd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f6365cff-430b-4374-babe-0ffdab5f1dbd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

