### PR TITLE
Adapt batch override modal for property-specific inputs

### DIFF
--- a/src/components/workspace/batch/BatchModal.tsx
+++ b/src/components/workspace/batch/BatchModal.tsx
@@ -6,8 +6,118 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { useBatchOverrides } from "@/hooks/use-batch-overrides";
 import { useBatchKeysForField } from "@/hooks/use-batch-keys";
+import {
+  NumberField,
+  ColorField,
+  TextareaField,
+  TextField,
+} from "@/components/ui/form-fields";
+import { AssetSelectionModal } from "@/components/workspace/media/asset-selection-modal";
+import NextImage from "next/image";
+import { ImageOff } from "lucide-react";
+import { api } from "@/trpc/react";
 
 type ValueType = "number" | "string";
+
+type FieldKind =
+  | "media-asset"
+  | "color"
+  | "textarea"
+  | "number"
+  | "string";
+
+function classifyField(fieldPath: string, fallback: ValueType): FieldKind {
+  // Media asset id
+  if (fieldPath === "Media.imageAssetId") return "media-asset";
+
+  // Colors (Canvas and Typography)
+  const colorFields = new Set([
+    "Canvas.fillColor",
+    "Canvas.strokeColor",
+    "Typography.fillColor",
+    "Typography.strokeColor",
+  ]);
+  if (colorFields.has(fieldPath)) return "color";
+
+  // Typography content
+  if (fieldPath === "Typography.content") return "textarea";
+
+  // Numeric fields across editors
+  const numberFields = new Set([
+    // Canvas
+    "Canvas.position.x",
+    "Canvas.position.y",
+    "Canvas.scale.x",
+    "Canvas.scale.y",
+    "Canvas.rotation",
+    "Canvas.opacity",
+    "Canvas.strokeWidth",
+    // Typography
+    "Typography.fontSize",
+    "Typography.strokeWidth",
+    // Media
+    "Media.cropX",
+    "Media.cropY",
+    "Media.cropWidth",
+    "Media.cropHeight",
+    "Media.displayWidth",
+    "Media.displayHeight",
+  ]);
+  if (numberFields.has(fieldPath)) return "number";
+
+  // Fallback to provided valueType
+  return fallback === "number" ? "number" : "string";
+}
+
+function AssetThumb({ assetId }: { assetId?: string }) {
+  const { data: assetDetails, isLoading } = api.assets.list.useQuery(
+    {
+      limit: 100,
+      offset: 0,
+      bucketName: "images",
+    },
+    {
+      enabled: !!assetId,
+      select: (response) =>
+        response.assets.find((asset) => asset.id === assetId),
+    },
+  );
+
+  if (!assetId) {
+    return (
+      <div className="flex h-12 w-12 items-center justify-center rounded bg-[var(--surface-1)]">
+        <ImageOff size={16} className="text-[var(--text-tertiary)]" />
+      </div>
+    );
+  }
+  if (isLoading) {
+    return (
+      <div className="flex h-12 w-12 items-center justify-center rounded bg-[var(--surface-1)]">
+        <div className="h-4 w-4 animate-spin rounded-full border-2 border-[var(--accent-primary)] border-t-transparent" />
+      </div>
+    );
+  }
+  if (!assetDetails) {
+    return (
+      <div className="flex h-12 w-12 items-center justify-center rounded bg-[var(--surface-1)]">
+        <ImageOff size={16} className="text-[var(--text-tertiary)]" />
+      </div>
+    );
+  }
+  return (
+    <div className="h-12 w-12 overflow-hidden rounded bg-[var(--surface-1)]">
+      {assetDetails.public_url && (
+        <NextImage
+          src={assetDetails.public_url}
+          alt={assetDetails.original_name}
+          width={48}
+          height={48}
+          className="h-full w-full object-cover"
+        />
+      )}
+    </div>
+  );
+}
 
 export function BatchModal({
   isOpen,
@@ -27,6 +137,7 @@ export function BatchModal({
   const { data, setPerObjectDefault, setPerKeyOverride, clearOverride } =
     useBatchOverrides(nodeId, fieldPath, objectId);
   const { keys } = useBatchKeysForField(nodeId, fieldPath, objectId);
+  const kind = classifyField(fieldPath, valueType);
 
   const [query, setQuery] = useState("");
   const filteredKeys = useMemo(() => {
@@ -41,28 +152,12 @@ export function BatchModal({
     return Object.keys(data.perKeyOverrides).filter((k) => !present.has(k));
   }, [data.perKeyOverrides, keys]);
 
-  const handleSet = (k: string, raw: string) => {
-    if (valueType === "number") {
-      const n = Number(raw);
-      if (!Number.isFinite(n)) return; // simple guard, avoid blocking UX
-      setPerKeyOverride(k, n);
-    } else {
-      setPerKeyOverride(k, raw);
-    }
-  };
-
-  const handleSetDefault = (raw: string) => {
-    if (valueType === "number") {
-      const n = Number(raw);
-      if (!Number.isFinite(n)) {
-        setPerObjectDefault(undefined);
-        return;
-      }
-      setPerObjectDefault(n);
-    } else {
-      setPerObjectDefault(raw);
-    }
-  };
+  // Media asset picker state
+  const [assetPicker, setAssetPicker] = useState<
+    | { scope: "default" }
+    | { scope: "key"; key: string }
+    | null
+  >(null);
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} title="Batch Overrides" size="lg">
@@ -85,27 +180,119 @@ export function BatchModal({
             <div className="text-xs font-semibold text-[var(--text-secondary)]">
               Default (all keys)
             </div>
-            <div className="flex items-center gap-[var(--space-2)]">
-              <Input
-                value={(() => {
-                  if (data.perObjectDefault == null) return "";
-                  if (
-                    typeof data.perObjectDefault === "object" &&
-                    data.perObjectDefault !== null
-                  ) {
-                    return JSON.stringify(data.perObjectDefault);
-                  }
-                  // At this point, data.perObjectDefault is not an object, so String() is safe
-                  return String(
-                    data.perObjectDefault as string | number | boolean,
+            {(() => {
+              switch (kind) {
+                case "media-asset": {
+                  const assetId = (data.perObjectDefault as string | undefined) || "";
+                  return (
+                    <div className="rounded border border-[var(--border-primary)] bg-[var(--surface-2)] p-2">
+                      <div className="flex items-center gap-[var(--space-2)]">
+                        <AssetThumb assetId={assetId} />
+                        <div className="flex-1" />
+                        <Button
+                          variant="secondary"
+                          size="xs"
+                          onClick={() => setAssetPicker({ scope: "default" })}
+                        >
+                          {assetId ? "Change Image" : "Select Image"}
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="xs"
+                          onClick={() => clearOverride()}
+                        >
+                          Clear
+                        </Button>
+                      </div>
+                    </div>
                   );
-                })()}
-                onChange={(e) => handleSetDefault(e.target.value)}
-              />
-              <Button variant="ghost" size="sm" onClick={() => clearOverride()}>
-                Clear
-              </Button>
-            </div>
+                }
+                case "color": {
+                  return (
+                    <div className="flex items-center gap-[var(--space-2)]">
+                      <ColorField
+                        label="Value"
+                        value={(data.perObjectDefault as string) || "#000000"}
+                        onChange={(v) => setPerObjectDefault(v)}
+                      />
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => clearOverride()}
+                      >
+                        Clear
+                      </Button>
+                    </div>
+                  );
+                }
+                case "textarea": {
+                  return (
+                    <div className="space-y-[var(--space-1)]">
+                      <TextareaField
+                        label="Value"
+                        value={(data.perObjectDefault as string) || ""}
+                        onChange={(v) => setPerObjectDefault(v)}
+                        rows={4}
+                      />
+                      <div className="text-right">
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => clearOverride()}
+                        >
+                          Clear
+                        </Button>
+                      </div>
+                    </div>
+                  );
+                }
+                case "number": {
+                  return (
+                    <div className="flex items-center gap-[var(--space-2)]">
+                      <NumberField
+                        label="Value"
+                        value={
+                          typeof data.perObjectDefault === "number"
+                            ? data.perObjectDefault
+                            : undefined
+                        }
+                        onChange={(n) => setPerObjectDefault(n)}
+                      />
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => clearOverride()}
+                      >
+                        Clear
+                      </Button>
+                    </div>
+                  );
+                }
+                case "string":
+                default: {
+                  return (
+                    <div className="flex items-center gap-[var(--space-2)]">
+                      <TextField
+                        label="Value"
+                        value={
+                          typeof data.perObjectDefault === "string"
+                            ? (data.perObjectDefault as string)
+                            : ""
+                        }
+                        onChange={(v) => setPerObjectDefault(v)}
+                      />
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => clearOverride()}
+                      >
+                        Clear
+                      </Button>
+                    </div>
+                  );
+                }
+              }
+            })()}
 
             <div className="mt-[var(--space-3)] text-xs font-semibold text-[var(--text-secondary)]">
               Keys ({filteredKeys.length})
@@ -127,20 +314,53 @@ export function BatchModal({
                         {k}
                       </div>
                       <div className="flex items-center gap-[var(--space-2)]">
-                        <Input
-                          value={(() => {
-                            if (current == null) return "";
-                            if (
-                              typeof current === "object" &&
-                              current !== null
-                            ) {
-                              return JSON.stringify(current);
+                        {kind === "media-asset" ? (
+                          <>
+                            <AssetThumb assetId={(current as string | undefined) || ""} />
+                            <Button
+                              variant="secondary"
+                              size="xs"
+                              onClick={() => setAssetPicker({ scope: "key", key: k })}
+                            >
+                              {(current as string | undefined) ? "Change" : "Select"}
+                            </Button>
+                          </>
+                        ) : kind === "color" ? (
+                          <input
+                            type="color"
+                            value={
+                              typeof current === "string" && current ? (current as string) : "#000000"
                             }
-                            // At this point, current is not an object, so String() is safe
-                            return String(current as string | number | boolean);
-                          })()}
-                          onChange={(e) => handleSet(k, e.target.value)}
-                        />
+                            onChange={(e) => setPerKeyOverride(k, e.target.value)}
+                            className="h-8 w-10 cursor-pointer rounded border border-[var(--border-primary)] bg-[var(--surface-2)]"
+                          />
+                        ) : kind === "textarea" ? (
+                          <textarea
+                            value={typeof current === "string" ? (current as string) : ""}
+                            onChange={(e) => setPerKeyOverride(k, e.target.value)}
+                            rows={2}
+                            className="min-w-[180px] resize-y rounded border border-[var(--border-primary)] bg-[var(--surface-2)] px-2 py-1 text-xs"
+                          />
+                        ) : kind === "number" ? (
+                          <Input
+                            type="number"
+                            value={
+                              typeof current === "number" || typeof current === "string"
+                                ? String(current)
+                                : ""
+                            }
+                            onChange={(e) => {
+                              const n = Number(e.target.value);
+                              if (!Number.isFinite(n)) return;
+                              setPerKeyOverride(k, n);
+                            }}
+                          />
+                        ) : (
+                          <Input
+                            value={typeof current === "string" ? (current as string) : ""}
+                            onChange={(e) => setPerKeyOverride(k, e.target.value)}
+                          />
+                        )}
                         <Button
                           variant="ghost"
                           size="sm"
@@ -201,6 +421,29 @@ export function BatchModal({
             Close
           </Button>
         </div>
+
+        {/* Media asset selection modal */}
+        {kind === "media-asset" && assetPicker ? (
+          <AssetSelectionModal
+            isOpen={true}
+            onClose={() => setAssetPicker(null)}
+            onSelect={(asset) => {
+              if (assetPicker.scope === "default") {
+                setPerObjectDefault(asset.id);
+              } else if (assetPicker.scope === "key") {
+                setPerKeyOverride(assetPicker.key, asset.id);
+              }
+              setAssetPicker(null);
+            }}
+            selectedAssetId={(() => {
+              if (assetPicker.scope === "default") {
+                return (data.perObjectDefault as string | undefined) || undefined;
+              }
+              const cur = data.perKeyOverrides[assetPicker.key];
+              return (cur as string | undefined) || undefined;
+            })()}
+          />)
+        : null}
       </div>
     </Modal>
   );


### PR DESCRIPTION
Implement adaptive input fields in the batch overrides modal to support specific property types like images, colors, and text areas.

---
<a href="https://cursor.com/background-agent?bcId=bc-5ff7b317-bef2-4122-89dc-134b71e662b3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5ff7b317-bef2-4122-89dc-134b71e662b3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

