### PR TITLE
Fix per key override for media and typography editors

### DIFF
--- a/src/server/animation-processing/scene/scene-partitioner.ts
+++ b/src/server/animation-processing/scene/scene-partitioner.ts
@@ -431,6 +431,9 @@ export function buildAnimationSceneFromPartition(
     for (const [objId, list] of Object.entries(perObjectBoundFields)) {
       for (const key of list) {
         if (key.startsWith("Timeline.")) add(objId, key);
+        if (key.startsWith("Canvas.")) add(objId, key);
+        if (key.startsWith("Typography.")) add(objId, key);
+        if (key.startsWith("Media.")) add(objId, key);
         const mapped = maybeMapTrackKey(key);
         for (const mk of mapped) add(objId, mk);
       }

--- a/src/server/api/routers/animation.ts
+++ b/src/server/api/routers/animation.ts
@@ -87,6 +87,22 @@ function namespaceBatchOverridesForBatch(
   return namespaced;
 }
 
+// Helper: namespace bound fields map to match namespaced object IDs
+function namespaceBoundFieldsForBatch(
+  bound:
+    | Record<string, string[]>
+    | undefined,
+  batchKey: string | null,
+): Record<string, string[]> | undefined {
+  if (!batchKey || !bound) return bound;
+  const suffix = `@${batchKey}`;
+  const out: Record<string, string[]> = {};
+  for (const [objectId, keys] of Object.entries(bound)) {
+    out[`${objectId}${suffix}`] = keys;
+  }
+  return out;
+}
+
 // Helper: create a fully namespaced partition for batch key processing
 function namespacePartitionForBatch(
   partition: ScenePartition,
@@ -100,7 +116,10 @@ function namespacePartitionForBatch(
       partition.batchOverrides,
       batchKey,
     ),
-    boundFieldsByObject: partition.boundFieldsByObject,
+    boundFieldsByObject: namespaceBoundFieldsForBatch(
+      partition.boundFieldsByObject,
+      batchKey,
+    ),
     batchKey: batchKey,
   };
 }


### PR DESCRIPTION
Fix per-key overrides for Media and Typography editors to correctly apply changes at render time.

Previously, per-key overrides for Media and Typography properties (e.g., `imageAssetId`, `content`) were not being reflected in the rendered output. This was due to inconsistencies in how bound fields were resolved, namespaced, and applied in the rendering pipeline. This PR aligns these editors with the existing, working override system used by Canvas and Timeline editors.

---
<a href="https://cursor.com/background-agent?bcId=bc-c5002da6-2be0-4583-aed7-de3c21891313">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c5002da6-2be0-4583-aed7-de3c21891313">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

