### PR TITLE
Fix per-key override conflict in editors

### DIFF
--- a/src/server/animation-processing/executors/animation-executor.ts
+++ b/src/server/animation-processing/executors/animation-executor.ts
@@ -309,6 +309,88 @@ export class AnimationNodeExecutor extends BaseExecutor {
       }
     }
 
+    // Merge upstream per-object batch overrides with this node's emitted overrides (this node wins on conflicts)
+    const upstreamPerObjectBatchOverrides = (() => {
+      const out: Record<string, Record<string, Record<string, unknown>>> = {};
+      for (const input of inputs) {
+        const meta = input.metadata as
+          | {
+              perObjectBatchOverrides?: Record<
+                string,
+                Record<string, Record<string, unknown>>
+              >;
+            }
+          | undefined;
+        const src = meta?.perObjectBatchOverrides;
+        if (!src) continue;
+        for (const [objectId, fields] of Object.entries(src)) {
+          const destFields = out[objectId] ?? {};
+          for (const [fieldPath, byKey] of Object.entries(fields)) {
+            const existing = destFields[fieldPath] ?? {};
+            destFields[fieldPath] = { ...existing, ...byKey };
+          }
+          out[objectId] = destFields;
+        }
+      }
+      return Object.keys(out).length > 0 ? out : undefined;
+    })();
+
+    const mergedPerObjectBatchOverrides = (() => {
+      const out: Record<string, Record<string, Record<string, unknown>>> = {};
+      const mergeInto = (
+        src:
+          | Record<string, Record<string, Record<string, unknown>>>
+          | undefined,
+      ) => {
+        if (!src) return;
+        for (const [objectId, fields] of Object.entries(src)) {
+          const destFields = out[objectId] ?? {};
+          for (const [fieldPath, byKey] of Object.entries(fields)) {
+            const existing = destFields[fieldPath] ?? {};
+            destFields[fieldPath] = { ...existing, ...byKey };
+          }
+          out[objectId] = destFields;
+        }
+      };
+      // Upstream first, then this node (this node wins for same keys)
+      mergeInto(upstreamPerObjectBatchOverrides);
+      mergeInto(emittedPerObjectBatchOverrides);
+      return Object.keys(out).length > 0 ? out : undefined;
+    })();
+
+    // Merge upstream bound field masks with this node's masks (union)
+    const upstreamPerObjectBoundFields = (() => {
+      const out: Record<string, string[]> = {};
+      for (const input of inputs) {
+        const meta = input.metadata as
+          | { perObjectBoundFields?: Record<string, string[]> }
+          | undefined;
+        const src = meta?.perObjectBoundFields;
+        if (!src) continue;
+        for (const [objectId, list] of Object.entries(src)) {
+          const existing = out[objectId] ?? [];
+          out[objectId] = Array.from(new Set([...existing, ...list.map(String)]));
+        }
+      }
+      return Object.keys(out).length > 0 ? out : undefined;
+    })();
+
+    const mergedPerObjectBoundFields = (() => {
+      const out: Record<string, string[]> = {};
+      const mergeInto = (
+        src: Record<string, string[]> | undefined,
+      ): void => {
+        if (!src) return;
+        for (const [objectId, keys] of Object.entries(src)) {
+          const existing = out[objectId] ?? [];
+          out[objectId] = Array.from(new Set([...existing, ...keys.map(String)]));
+        }
+      };
+      mergeInto(upstreamPerObjectBoundFields);
+      mergeInto(perObjectBoundFields);
+      return Object.keys(out).length > 0 ? out : undefined;
+    })();
+
     setNodeOutput(
       context,
       node.data.identifier.id,
@@ -319,15 +401,8 @@ export class AnimationNodeExecutor extends BaseExecutor {
         perObjectTimeCursor: this.extractCursorsFromInputs(inputs),
         perObjectAnimations: this.extractPerObjectAnimationsFromInputs(inputs),
         perObjectAssignments: mergedAssignments,
-        perObjectBatchOverrides:
-          Object.keys(emittedPerObjectBatchOverrides).length > 0
-            ? emittedPerObjectBatchOverrides
-            : undefined,
-        // Ensure bound fields are passed even if empty to maintain consistency
-        perObjectBoundFields:
-          Object.keys(perObjectBoundFields).length > 0
-            ? perObjectBoundFields
-            : undefined,
+        perObjectBatchOverrides: mergedPerObjectBatchOverrides,
+        perObjectBoundFields: mergedPerObjectBoundFields,
       },
     );
 
@@ -1664,6 +1739,117 @@ export class AnimationNodeExecutor extends BaseExecutor {
       }
     }
 
+    // Merge upstream per-object batch overrides with this node's emitted overrides (this node wins on conflicts)
+    const upstreamPerObjectBatchOverrides = (() => {
+      const out: Record<string, Record<string, Record<string, unknown>>> = {};
+      const mergeInto = (
+        src:
+          | Record<string, Record<string, Record<string, unknown>>>
+          | undefined,
+      ) => {
+        if (!src) return;
+        for (const [objectId, fields] of Object.entries(src)) {
+          const destFields = out[objectId] ?? {};
+          for (const [fieldPath, byKey] of Object.entries(fields)) {
+            const existing = destFields[fieldPath] ?? {};
+            destFields[fieldPath] = { ...existing, ...byKey };
+          }
+          out[objectId] = destFields;
+        }
+      };
+      for (const input of inputs) {
+        const meta = input.metadata as
+          | {
+              perObjectBatchOverrides?: Record<
+                string,
+                Record<string, Record<string, unknown>>
+              >;
+            }
+          | undefined;
+        mergeInto(meta?.perObjectBatchOverrides);
+      }
+      return Object.keys(out).length > 0 ? out : undefined;
+    })();
+
+    const mergedPerObjectBatchOverrides = (() => {
+      const out: Record<string, Record<string, Record<string, unknown>>> = {};
+      const mergeInto = (
+        src:
+          | Record<string, Record<string, Record<string, unknown>>>
+          | undefined,
+      ) => {
+        if (!src) return;
+        for (const [objectId, fields] of Object.entries(src)) {
+          const destFields = out[objectId] ?? {};
+          for (const [fieldPath, byKey] of Object.entries(fields)) {
+            const existing = destFields[fieldPath] ?? {};
+            destFields[fieldPath] = { ...existing, ...byKey };
+          }
+          out[objectId] = destFields;
+        }
+      };
+      mergeInto(upstreamPerObjectBatchOverrides);
+      mergeInto(emittedPerObjectBatchOverrides);
+      return Object.keys(out).length > 0 ? out : undefined;
+    })();
+
+    // Merge upstream bound fields with this node's bound fields (normalize Typography.* keys for current node)
+    const normalizedTypoBound: Record<string, string[]> = Object.fromEntries(
+      Object.entries(perObjectBoundFieldsTypo).map(([objId, keys]) => [
+        objId,
+        keys.map((k) =>
+          k.startsWith("Typography.")
+            ? k
+            : [
+                "content",
+                "fontFamily",
+                "fontSize",
+                "fontWeight",
+                "textAlign",
+                "lineHeight",
+                "letterSpacing",
+                "fontStyle",
+                "textBaseline",
+                "direction",
+                "fillColor",
+                "strokeColor",
+                "strokeWidth",
+              ].includes(k)
+              ? `Typography.${k}`
+              : k,
+        ),
+      ])
+    );
+
+    const upstreamPerObjectBoundFields = (() => {
+      const out: Record<string, string[]> = {};
+      for (const input of inputs) {
+        const meta = input.metadata as
+          | { perObjectBoundFields?: Record<string, string[]> }
+          | undefined;
+        if (!meta?.perObjectBoundFields) continue;
+        for (const [objId, list] of Object.entries(meta.perObjectBoundFields)) {
+          const existing = out[objId] ?? [];
+          out[objId] = Array.from(new Set([...existing, ...list.map(String)]));
+        }
+      }
+      return Object.keys(out).length > 0 ? out : undefined;
+    })();
+
+    const mergedPerObjectBoundFields = (() => {
+      const out: Record<string, string[]> = {};
+      const mergeInto = (src: Record<string, string[]> | undefined) => {
+        if (!src) return;
+        for (const [objId, list] of Object.entries(src)) {
+          const existing = out[objId] ?? [];
+          out[objId] = Array.from(new Set([...existing, ...list.map(String)]));
+        }
+      };
+      mergeInto(upstreamPerObjectBoundFields);
+      mergeInto(normalizedTypoBound);
+      return Object.keys(out).length > 0 ? out : undefined;
+    })();
+
     setNodeOutput(
       context,
       node.data.identifier.id,
@@ -1674,44 +1860,9 @@ export class AnimationNodeExecutor extends BaseExecutor {
         perObjectTimeCursor: outputCursorMap,
         perObjectAnimations: this.clonePerObjectAnimations(perObjectAnimations),
         perObjectAssignments: mergedAssignments,
-        perObjectBatchOverrides:
-          Object.keys(emittedPerObjectBatchOverrides).length > 0
-            ? emittedPerObjectBatchOverrides
-            : undefined,
-        // Provide bound field masks for Typography so resolver masks overrides correctly
-        perObjectBoundFields:
-          Object.keys(perObjectBoundFieldsTypo).length > 0
-            ? Object.fromEntries(
-                Object.entries(perObjectBoundFieldsTypo).map(
-                  ([objId, keys]) => [
-                    objId,
-                    keys
-                      // Normalize Typography keys into resolver field paths
-                      .map((k) =>
-                        k.startsWith("Typography.")
-                          ? k
-                          : [
-                              "content",
-                              "fontFamily",
-                              "fontSize",
-                              "fontWeight",
-                              "textAlign",
-                              "lineHeight",
-                              "letterSpacing",
-                              "fontStyle",
-                              "textBaseline",
-                              "direction",
-                              "fillColor",
-                              "strokeColor",
-                              "strokeWidth",
-                            ].includes(k)
-                            ? `Typography.${k}`
-                            : k,
-                      ),
-                  ],
-                ),
-              )
-            : undefined,
+        perObjectBatchOverrides: mergedPerObjectBatchOverrides,
+        // Provide bound field masks merged with upstream so resolver masks overrides correctly
+        perObjectBoundFields: mergedPerObjectBoundFields,
       },
     );
 

--- a/src/server/animation-processing/executors/canvas-executor.ts
+++ b/src/server/animation-processing/executors/canvas-executor.ts
@@ -456,6 +456,45 @@ export class CanvasNodeExecutor extends BaseExecutor {
       if (combined.length > 0) perObjectBoundFields[objectId] = combined;
     }
 
+    // Merge upstream per-object batch overrides with this node's emitted overrides (this node wins on conflicts)
+    const upstreamPerObjectBatchOverrides = firstMeta?.perObjectBatchOverrides;
+    const mergedPerObjectBatchOverrides = (() => {
+      const out: Record<string, Record<string, Record<string, unknown>>> = {};
+      const mergeInto = (
+        src:
+          | Record<string, Record<string, Record<string, unknown>>>
+          | undefined,
+      ) => {
+        if (!src) return;
+        for (const [objectId, fields] of Object.entries(src)) {
+          const destFields = out[objectId] ?? {};
+          for (const [fieldPath, byKey] of Object.entries(fields)) {
+            const existing = destFields[fieldPath] ?? {};
+            destFields[fieldPath] = { ...existing, ...byKey };
+          }
+          out[objectId] = destFields;
+        }
+      };
+      mergeInto(upstreamPerObjectBatchOverrides);
+      mergeInto(emittedPerObjectBatchOverrides);
+      return Object.keys(out).length > 0 ? out : undefined;
+    })();
+
+    // Merge upstream bound field masks with this node's masks (union)
+    const mergedPerObjectBoundFields = (() => {
+      const out: Record<string, string[]> = {};
+      const mergeInto = (src: Record<string, string[]> | undefined) => {
+        if (!src) return;
+        for (const [objectId, keys] of Object.entries(src)) {
+          const existing = out[objectId] ?? [];
+          out[objectId] = Array.from(new Set([...existing, ...keys.map(String)]));
+        }
+      };
+      mergeInto(firstMeta?.perObjectBoundFields);
+      mergeInto(perObjectBoundFields);
+      return Object.keys(out).length > 0 ? out : undefined;
+    })();
+
     setNodeOutput(
       context,
       node.data.identifier.id,
@@ -467,14 +506,8 @@ export class CanvasNodeExecutor extends BaseExecutor {
         perObjectAnimations: firstMeta?.perObjectAnimations,
         perObjectAssignments:
           mergedAssignments ?? firstMeta?.perObjectAssignments,
-        perObjectBatchOverrides:
-          Object.keys(emittedPerObjectBatchOverrides).length > 0
-            ? emittedPerObjectBatchOverrides
-            : firstMeta?.perObjectBatchOverrides,
-        perObjectBoundFields:
-          Object.keys(perObjectBoundFields).length > 0
-            ? perObjectBoundFields
-            : firstMeta?.perObjectBoundFields,
+        perObjectBatchOverrides: mergedPerObjectBatchOverrides,
+        perObjectBoundFields: mergedPerObjectBoundFields,
       },
     );
   }


### PR DESCRIPTION
Merge per-object batch overrides and bound field masks in Media, Typography, and Canvas executors to resolve conflicts when multiple editors apply per-key overrides.

Previously, `perObjectBatchOverrides` and `perObjectBoundFields` were being overwritten or replaced by the last processed input or the current node, leading to conflicts where only one editor's per-key overrides would take effect. This fix implements a robust deep-merge strategy, ensuring that overrides and bound fields from all upstream inputs and the current node are combined and applied simultaneously.

---
<a href="https://cursor.com/background-agent?bcId=bc-0f5dc188-4ebd-4d6a-afd6-696d47ebb6b0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0f5dc188-4ebd-4d6a-afd6-696d47ebb6b0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

