### PR TITLE
Refactor timeline editor for per-axis scale

### DIFF
--- a/src/components/workspace/timeline-editor-tab.tsx
+++ b/src/components/workspace/timeline-editor-tab.tsx
@@ -201,35 +201,7 @@ export function TimelineEditorTab({ nodeId }: { nodeId: string }) {
     () => ({
       animationNodeId: nodeId,
       duration: data?.duration ?? 0,
-      tracks:
-        (data?.tracks ?? []).map((t) => {
-          if (t.type !== "scale") return t;
-          const props = t.properties as unknown as {
-            from?: number | { x?: number; y?: number };
-            to?: number | { x?: number; y?: number };
-          };
-          const fromObj =
-            typeof props.from === "number"
-              ? { x: props.from, y: props.from }
-              : (props.from ?? { x: 1, y: 1 });
-          const toObj =
-            typeof props.to === "number"
-              ? { x: props.to, y: props.to }
-              : (props.to ?? { x: 1, y: 1 });
-          return {
-            ...t,
-            properties: {
-              from: {
-                x: typeof fromObj.x === "number" ? fromObj.x : 1,
-                y: typeof fromObj.y === "number" ? fromObj.y : 1,
-              },
-              to: {
-                x: typeof toObj.x === "number" ? toObj.x : 1,
-                y: typeof toObj.y === "number" ? toObj.y : 1,
-              },
-            },
-          } as AnimationTrack;
-        }) ?? [],
+      tracks: data?.tracks ?? [],
     }),
     [nodeId, data?.duration, data?.tracks],
   );


### PR DESCRIPTION
Remove redundant scale normalization in `timeline-editor-tab.tsx` to enable independent per-axis scale fields and align with the move transform pattern.

The previous normalization logic in `timeline-editor-tab.tsx` was shaping `scale.from` and `scale.to` into grouped `x, y` objects. This prevented the core system from treating `scale.from.x`, `scale.from.y`, `scale.to.x`, and `scale.to.y` as independent fields for overrides and bindings, which is crucial for the new per-axis scale implementation. Removing this legacy code ensures consistency and proper functionality of the new independent scale fields.

---
<a href="https://cursor.com/background-agent?bcId=bc-e41d6d72-2c54-41a0-b6b5-841f2ab23965">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e41d6d72-2c54-41a0-b6b5-841f2ab23965">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

