### PR TITLE
Make insert node object aware with modal controls

### DIFF
--- a/src/components/workspace/binding/bindings.tsx
+++ b/src/components/workspace/binding/bindings.tsx
@@ -10,6 +10,7 @@ import type {
   CanvasNodeData,
   TypographyNodeData,
   MediaNodeData,
+  InsertNodeData,
 } from "@/shared/types/nodes";
 import type {
   PerObjectAssignments,
@@ -45,6 +46,11 @@ function isMediaNodeData(data: NodeData): data is MediaNodeData {
   return data.identifier.type === "media";
 }
 
+// NEW: Add Insert support
+function isInsertNodeData(data: NodeData): data is InsertNodeData {
+  return data.identifier.type === "insert";
+}
+
 // Helper type for variable binding structure
 interface VariableBinding {
   target?: string;
@@ -77,7 +83,8 @@ export function useVariableBinding(nodeId: string, objectId?: string) {
         isAnimationNodeData(node.data) ||
         isCanvasNodeData(node.data) ||
         isTypographyNodeData(node.data) ||
-        isMediaNodeData(node.data)
+        isMediaNodeData(node.data) ||
+        isInsertNodeData(node.data)
       ) {
         const prevAll = node.data.variableBindingsByObject ?? {};
         return prevAll[objectId]?.[key]?.boundResultNodeId;
@@ -89,7 +96,8 @@ export function useVariableBinding(nodeId: string, objectId?: string) {
       isAnimationNodeData(node.data) ||
       isCanvasNodeData(node.data) ||
       isTypographyNodeData(node.data) ||
-      isMediaNodeData(node.data)
+      isMediaNodeData(node.data) ||
+      isInsertNodeData(node.data)
     ) {
       const vb = node.data.variableBindings ?? {};
       return vb[key]?.boundResultNodeId;
@@ -175,7 +183,8 @@ export function useVariableBinding(nodeId: string, objectId?: string) {
           (!isAnimationNodeData(nodeData) &&
             !isCanvasNodeData(nodeData) &&
             !isTypographyNodeData(nodeData) &&
-            !isMediaNodeData(nodeData))
+            !isMediaNodeData(nodeData) &&
+            !isInsertNodeData(nodeData))
         ) {
           return n;
         }
@@ -225,7 +234,8 @@ export function useVariableBinding(nodeId: string, objectId?: string) {
           !isAnimationNodeData(data) &&
           !isCanvasNodeData(data) &&
           !isTypographyNodeData(data) &&
-          !isMediaNodeData(data)
+          !isMediaNodeData(data) &&
+          !isInsertNodeData(data)
         ) {
           return n;
         }
@@ -363,6 +373,8 @@ export function useVariableBinding(nodeId: string, objectId?: string) {
           } else {
             // Node-level Media value is the node's default; do not change it here
           }
+        } else if (isInsertNodeData(nextData)) {
+          // For Insert, resetting binding only clears the binding; manual times remain
         }
 
         return { ...n, data: nextData };

--- a/src/components/workspace/nodes/InsertModal.tsx
+++ b/src/components/workspace/nodes/InsertModal.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import React, { useMemo } from "react";
+import { Modal } from "@/components/ui/modal";
+import { NumberField } from "@/components/ui/form-fields";
+import { Button } from "@/components/ui/button";
+import { BindButton } from "@/components/workspace/binding/bindings";
+import { useWorkspace } from "@/components/workspace/workspace-context";
+import { FlowTracker } from "@/lib/flow/flow-tracking";
+import type { NodeData, InsertNodeData } from "@/shared/types/nodes";
+
+export function InsertModal({
+  isOpen,
+  onClose,
+  nodeId,
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+  nodeId: string;
+}) {
+  const { state, updateFlow } = useWorkspace();
+  const node = state.flow.nodes.find(
+    (n) => n.data?.identifier?.id === nodeId,
+  );
+  const data = (node?.data ?? {}) as unknown as InsertNodeData & {
+    appearanceTimeByObject?: Record<string, number>;
+    variableBindings?: Record<string, { boundResultNodeId?: string }>;
+    variableBindingsByObject?: Record<
+      string,
+      Record<string, { boundResultNodeId?: string }>
+    >;
+  };
+
+  const defaultTime = Number(data.appearanceTime ?? 0);
+  const isDefaultBound = !!data.variableBindings?.appearanceTime?.boundResultNodeId;
+
+  const objects = useMemo(() => {
+    const tracker = new FlowTracker();
+    return tracker.getUpstreamObjects(
+      nodeId,
+      state.flow.nodes,
+      state.flow.edges,
+    );
+  }, [nodeId, state.flow.nodes, state.flow.edges]);
+
+  const setDefaultTime = (value: number) => {
+    updateFlow({
+      nodes: state.flow.nodes.map((n) =>
+        n.data?.identifier?.id !== nodeId
+          ? n
+          : ({
+              ...n,
+              data: { ...n.data, appearanceTime: value } as NodeData,
+            } as typeof n),
+      ),
+    });
+  };
+
+  const resetDefaultTime = () => setDefaultTime(0);
+
+  const setPerObjectTime = (objectId: string, value: number) => {
+    updateFlow({
+      nodes: state.flow.nodes.map((n) => {
+        if (n.data?.identifier?.id !== nodeId) return n;
+        const prev = (n.data as InsertNodeData).appearanceTimeByObject ?? {};
+        return {
+          ...n,
+          data: {
+            ...n.data,
+            appearanceTimeByObject: { ...prev, [objectId]: value },
+          } as NodeData,
+        };
+      }),
+    });
+  };
+
+  const clearPerObjectTime = (objectId: string) => {
+    updateFlow({
+      nodes: state.flow.nodes.map((n) => {
+        if (n.data?.identifier?.id !== nodeId) return n;
+        const prev =
+          ((n.data as InsertNodeData).appearanceTimeByObject ?? {}) as Record<
+            string,
+            number
+          >;
+        const next = { ...prev };
+        delete next[objectId];
+        return {
+          ...n,
+          data: {
+            ...n.data,
+            ...(Object.keys(next).length > 0
+              ? { appearanceTimeByObject: next }
+              : { appearanceTimeByObject: undefined }),
+          } as NodeData,
+        };
+      }),
+    });
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Insert: Appearance Time" size="lg">
+      <div className="p-[var(--space-4)]">
+        <div className="mb-[var(--space-4)] grid grid-cols-2 gap-[var(--space-4)]">
+          <div>
+            <NumberField
+              label="Default appearance time (seconds)"
+              value={defaultTime}
+              onChange={(v) => setDefaultTime(v)}
+              min={0}
+              step={0.1}
+              bindAdornment={<BindButton nodeId={nodeId} bindingKey="appearanceTime" />}
+              disabled={isDefaultBound}
+            />
+            <div className="mt-[var(--space-2)] text-right">
+              <Button variant="ghost" size="sm" onClick={resetDefaultTime}>
+                Reset to 0
+              </Button>
+            </div>
+          </div>
+          <div className="text-xs text-[var(--text-secondary)]">
+            Set when objects become visible. Default applies to all objects unless a per-object value or binding is set. Bound values come from Result nodes.
+          </div>
+        </div>
+
+        <div className="text-sm font-semibold text-[var(--text-secondary)]">
+          Per-object appearance times
+        </div>
+
+        <div className="mt-[var(--space-2)] grid grid-cols-2 gap-[var(--space-4)]">
+          <div className="text-xs text-[var(--text-tertiary)]">Object</div>
+          <div className="text-xs text-[var(--text-tertiary)]">Time (s)</div>
+        </div>
+
+        <div className="mt-[var(--space-2)] max-h-[420px] space-y-[var(--space-2)] overflow-auto pr-[var(--space-1)]">
+          {objects.length === 0 ? (
+            <div className="rounded border border-[var(--border-secondary)] p-[var(--space-3)] text-xs text-[var(--text-tertiary)]">
+              No upstream objects connected to this Insert node.
+            </div>
+          ) : (
+            objects.map((obj) => {
+              const perObjectBindingId = data.variableBindingsByObject?.[obj.id]?.appearanceTime?.boundResultNodeId;
+              const isBound = !!perObjectBindingId;
+              const value = data.appearanceTimeByObject?.[obj.id];
+              return (
+                <div
+                  key={obj.id}
+                  className="grid grid-cols-2 items-center gap-[var(--space-4)] rounded border border-[var(--border-primary)] bg-[var(--surface-2)] px-[var(--space-2)] py-[var(--space-1)]"
+                >
+                  <div className="truncate text-sm text-[var(--text-primary)]" title={obj.displayName}>
+                    {obj.displayName}
+                  </div>
+                  <div className="flex items-center gap-[var(--space-2)]">
+                    <div className="flex-1">
+                      <NumberField
+                        label=""
+                        value={value}
+                        onChange={(v) => setPerObjectTime(obj.id, v)}
+                        min={0}
+                        step={0.1}
+                        bindAdornment={<BindButton nodeId={nodeId} bindingKey="appearanceTime" objectId={obj.id} />}
+                        disabled={isBound}
+                      />
+                    </div>
+                    {value !== undefined && (
+                      <Button variant="ghost" size="xs" onClick={() => clearPerObjectTime(obj.id)}>
+                        Clear
+                      </Button>
+                    )}
+                  </div>
+                </div>
+              );
+            })
+          )}
+        </div>
+
+        <div className="mt-[var(--space-3)] text-right text-[10px] text-[var(--text-tertiary)]">
+          Changes apply immediately. Use Save to persist your workspace.
+        </div>
+      </div>
+    </Modal>
+  );
+}
+

--- a/src/components/workspace/nodes/insert-node.tsx
+++ b/src/components/workspace/nodes/insert-node.tsx
@@ -5,16 +5,20 @@ import { Handle, Position, type NodeProps } from "reactflow";
 import { Card, CardHeader, CardContent } from "@/components/ui/card";
 import { getNodeDefinition } from "@/shared/registry/registry-utils";
 import type { InsertNodeData } from "@/shared/types/nodes";
+import React from "react";
+import { InsertModal } from "./InsertModal";
 
 export function InsertNode({ data, selected }: NodeProps<InsertNodeData>) {
   const nodeDefinition = getNodeDefinition("insert");
+  const [open, setOpen] = React.useState(false);
 
   const handleClass = "bg-[var(--node-data)]";
 
   return (
     <Card
       selected={selected}
-      className="min-w-[var(--node-min-width)] p-[var(--card-padding)]"
+      className="min-w-[var(--node-min-width)] cursor-pointer p-[var(--card-padding)]"
+      onDoubleClick={() => setOpen(true)}
     >
       {/* Single input port */}
       {nodeDefinition?.ports.inputs.map((port) => (
@@ -41,11 +45,9 @@ export function InsertNode({ data, selected }: NodeProps<InsertNodeData>) {
 
       <CardContent className="space-y-1 p-0 text-xs text-[var(--text-secondary)]">
         <div>Appears at: {data.appearanceTime}s</div>
-        {data.appearanceTime === 0 ? (
-          <div className="text-[var(--success-500)]">Instant presence</div>
-        ) : (
-          <div className="text-[var(--accent-primary)]">Delayed presence</div>
-        )}
+        <div className="pt-1 text-[10px] text-[var(--text-tertiary)]">
+          Double-click to edit per-object times
+        </div>
       </CardContent>
 
       {/* Single output port */}
@@ -59,6 +61,13 @@ export function InsertNode({ data, selected }: NodeProps<InsertNodeData>) {
           style={{ top: `50%` }}
         />
       ))}
+      {open ? (
+        <InsertModal
+          isOpen={open}
+          onClose={() => setOpen(false)}
+          nodeId={data.identifier.id}
+        />
+      ) : null}
     </Card>
   );
 }

--- a/src/shared/types/nodes.ts
+++ b/src/shared/types/nodes.ts
@@ -98,6 +98,26 @@ export interface TypographyNodeData extends BaseNodeData {
 // Insert node data
 export interface InsertNodeData extends BaseNodeData {
   appearanceTime: number;
+  // Optional per-object appearance times overriding the default
+  appearanceTimeByObject?: Record<string, number>;
+  // Variable binding support (bind appearanceTime from Result nodes)
+  variableBindings?: Record<
+    string,
+    {
+      target?: string;
+      boundResultNodeId?: string;
+    }
+  >;
+  variableBindingsByObject?: Record<
+    string,
+    Record<
+      string,
+      {
+        target?: string;
+        boundResultNodeId?: string;
+      }
+    >
+  >;
 }
 
 // Filter node data


### PR DESCRIPTION
Enable per-object appearance time configuration for Insert nodes, allowing distinct timing for individual objects via a new modal with binding support.

---
<a href="https://cursor.com/background-agent?bcId=bc-082a04de-86ff-43fa-b82d-0e4beae1d925">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-082a04de-86ff-43fa-b82d-0e4beae1d925">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

