### PR TITLE
Rewrite landing page with pilot-focused messaging

### DIFF
--- a/src/app/_components/early-access-form.tsx
+++ b/src/app/_components/early-access-form.tsx
@@ -1,0 +1,183 @@
+'use client';
+
+import { type FormEvent, useState } from 'react';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+
+interface FormStatus {
+  type: 'idle' | 'success' | 'error';
+  message: string;
+}
+
+const useCaseOptions = [
+  { value: 'weekly-promos', label: 'Weekly promos' },
+  { value: 'marketplaces', label: 'Marketplaces' },
+  { value: 'social', label: 'Social campaigns' },
+  { value: 'in-store', label: 'In-store screens' },
+  { value: 'other', label: 'Other' },
+];
+
+const skuRangeOptions = [
+  'Under 500 SKUs',
+  '500 – 2,000 SKUs',
+  '2,000 – 5,000 SKUs',
+  '5,000+ SKUs',
+];
+
+export function EarlyAccessForm() {
+  const [status, setStatus] = useState<FormStatus>({ type: 'idle', message: '' });
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const form = event.currentTarget;
+    const formData = new FormData(form);
+
+    const payload = {
+      name: (formData.get('name') as string)?.trim(),
+      email: (formData.get('email') as string)?.trim(),
+      company: (formData.get('company') as string)?.trim(),
+      role: (formData.get('role') as string)?.trim(),
+      useCase: (formData.get('useCase') as string)?.trim(),
+      regions: (formData.get('regions') as string)?.trim(),
+      skuRange: (formData.get('skuRange') as string)?.trim(),
+    };
+
+    setIsSubmitting(true);
+
+    try {
+      const response = await fetch('/api/early-access', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+
+      if (!response.ok) {
+        const error = await response.json().catch(() => null);
+        throw new Error(error?.error ?? 'Unable to submit the form.');
+      }
+
+      setStatus({ type: 'success', message: 'Thank you—our team will be in touch within 2 business days.' });
+      form.reset();
+    } catch (error) {
+      setStatus({
+        type: 'error',
+        message: error instanceof Error ? error.message : 'Something went wrong. Please try again or email hello@variota.com.',
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <form className="space-y-6" onSubmit={handleSubmit} noValidate>
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="flex flex-col gap-2">
+          <label htmlFor="name" className="text-xs font-medium uppercase tracking-wide text-[var(--text-tertiary)]">
+            Name
+          </label>
+          <Input id="name" name="name" placeholder="Ada Lovelace" required autoComplete="name" />
+        </div>
+        <div className="flex flex-col gap-2">
+          <label htmlFor="email" className="text-xs font-medium uppercase tracking-wide text-[var(--text-tertiary)]">
+            Email
+          </label>
+          <Input
+            id="email"
+            name="email"
+            type="email"
+            placeholder="ada@retailco.com"
+            required
+            autoComplete="email"
+          />
+        </div>
+        <div className="flex flex-col gap-2">
+          <label htmlFor="company" className="text-xs font-medium uppercase tracking-wide text-[var(--text-tertiary)]">
+            Company
+          </label>
+          <Input id="company" name="company" placeholder="RetailCo" required autoComplete="organization" />
+        </div>
+        <div className="flex flex-col gap-2">
+          <label htmlFor="role" className="text-xs font-medium uppercase tracking-wide text-[var(--text-tertiary)]">
+            Role
+          </label>
+          <Input id="role" name="role" placeholder="Head of Merchandising" required autoComplete="organization-title" />
+        </div>
+        <div className="flex flex-col gap-2">
+          <label htmlFor="useCase" className="text-xs font-medium uppercase tracking-wide text-[var(--text-tertiary)]">
+            Primary use case
+          </label>
+          <select
+            id="useCase"
+            name="useCase"
+            required
+            defaultValue=""
+            className="glass-input w-full appearance-none rounded-[var(--radius-sm)] bg-transparent px-[var(--space-3)] py-[var(--space-2)] text-sm text-[var(--text-primary)] focus:outline-none"
+          >
+            <option value="" disabled>
+              Choose one
+            </option>
+            {useCaseOptions.map((option) => (
+              <option key={option.value} value={option.value} className="bg-[var(--surface-1)] text-[var(--text-primary)]">
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="flex flex-col gap-2">
+          <label htmlFor="skuRange" className="text-xs font-medium uppercase tracking-wide text-[var(--text-tertiary)]">
+            Approximate SKU range
+          </label>
+          <select
+            id="skuRange"
+            name="skuRange"
+            required
+            defaultValue=""
+            className="glass-input w-full appearance-none rounded-[var(--radius-sm)] bg-transparent px-[var(--space-3)] py-[var(--space-2)] text-sm text-[var(--text-primary)] focus:outline-none"
+          >
+            <option value="" disabled>
+              Select a range
+            </option>
+            {skuRangeOptions.map((option) => (
+              <option key={option} value={option} className="bg-[var(--surface-1)] text-[var(--text-primary)]">
+                {option}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="sm:col-span-2">
+          <div className="flex flex-col gap-2">
+            <label htmlFor="regions" className="text-xs font-medium uppercase tracking-wide text-[var(--text-tertiary)]">
+              Regions you operate in
+            </label>
+            <Input id="regions" name="regions" placeholder="North America, DACH, APAC" required />
+          </div>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <Button type="submit" variant="primary" size="md" disabled={isSubmitting} className="sm:w-auto">
+          {isSubmitting ? 'Submitting…' : 'Request Early Access'}
+        </Button>
+        <span className="text-xs text-[var(--text-tertiary)]">
+          Need help now? Email <a className="underline" href="mailto:hello@variota.com">hello@variota.com</a>
+        </span>
+      </div>
+
+      <p
+        role="status"
+        aria-live="polite"
+        className={`text-sm ${
+          status.type === 'success'
+            ? 'text-[var(--accent-success)]'
+            : status.type === 'error'
+              ? 'text-[var(--danger-500)]'
+              : 'text-[var(--text-tertiary)]'
+        }`}
+      >
+        {status.message}
+      </p>
+    </form>
+  );
+}

--- a/src/app/_components/subscribe-form.tsx
+++ b/src/app/_components/subscribe-form.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import { type FormEvent, useState } from 'react';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+
+interface FormStatus {
+  type: 'idle' | 'success' | 'error';
+  message: string;
+}
+
+export function SubscribeForm() {
+  const [status, setStatus] = useState<FormStatus>({ type: 'idle', message: '' });
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const form = event.currentTarget;
+    const formData = new FormData(form);
+    const email = (formData.get('email') as string)?.trim();
+
+    if (!email) {
+      setStatus({ type: 'error', message: 'Please enter a valid email address.' });
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      const response = await fetch('/api/subscribe', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email }),
+      });
+
+      if (!response.ok) {
+        const error = await response.json().catch(() => null);
+        throw new Error(error?.error ?? 'Unable to subscribe right now.');
+      }
+
+      setStatus({ type: 'success', message: 'Subscribed. We’ll keep you posted on product updates.' });
+      form.reset();
+    } catch (error) {
+      setStatus({
+        type: 'error',
+        message: error instanceof Error ? error.message : 'Something went wrong. Try again or email hello@variota.com.',
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-3" noValidate>
+      <div className="flex flex-col gap-3 sm:flex-row">
+        <Input
+          id="subscribe-email"
+          name="email"
+          type="email"
+          placeholder="you@retailco.com"
+          required
+          aria-label="Email address"
+          autoComplete="email"
+        />
+        <Button type="submit" variant="secondary" size="md" disabled={isSubmitting} className="sm:w-auto">
+          {isSubmitting ? 'Sending…' : 'Subscribe'}
+        </Button>
+      </div>
+      <p
+        role="status"
+        aria-live="polite"
+        className={`text-xs ${
+          status.type === 'success'
+            ? 'text-[var(--accent-success)]'
+            : status.type === 'error'
+              ? 'text-[var(--danger-500)]'
+              : 'text-[var(--text-tertiary)]'
+        }`}
+      >
+        {status.message || 'Monthly updates. No spam. You can unsubscribe anytime.'}
+      </p>
+    </form>
+  );
+}

--- a/src/app/api/early-access/route.ts
+++ b/src/app/api/early-access/route.ts
@@ -1,0 +1,70 @@
+import { NextResponse } from 'next/server';
+
+const requiredFields = ['name', 'email', 'company', 'role', 'useCase', 'regions', 'skuRange'] as const;
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+
+    const missing = requiredFields.filter((field) => {
+      const value = (body?.[field] as string | undefined)?.toString().trim();
+      return !value;
+    });
+
+    if (missing.length > 0) {
+      return NextResponse.json(
+        { error: `Missing required fields: ${missing.join(', ')}` },
+        { status: 400 }
+      );
+    }
+
+    const email = (body.email as string).toLowerCase();
+    const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailPattern.test(email)) {
+      return NextResponse.json({ error: 'Please provide a valid email address.' }, { status: 400 });
+    }
+
+    const payload = {
+      ...body,
+      email,
+      submittedAt: new Date().toISOString(),
+      source: 'landing-page',
+    } satisfies Record<string, unknown>;
+
+    if (process.env.EARLY_ACCESS_WEBHOOK_URL) {
+      try {
+        const response = await fetch(process.env.EARLY_ACCESS_WEBHOOK_URL, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        });
+
+        if (!response.ok) {
+          throw new Error(`Webhook responded with ${response.status}`);
+        }
+      } catch (error) {
+        console.error('Failed to forward early access request', error);
+        return NextResponse.json(
+          {
+            error:
+              'We captured your request but could not notify the team automatically. Please email hello@variota.com so we can follow up.',
+          },
+          { status: 502 }
+        );
+      }
+    } else {
+      // TODO: Connect to CRM or support tooling webhook when available.
+      console.info('Early access request received', payload);
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Unexpected error while processing early access request', error);
+    return NextResponse.json(
+      {
+        error: 'Unexpected error. Please try again or contact hello@variota.com.',
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/subscribe/route.ts
+++ b/src/app/api/subscribe/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from 'next/server';
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const email = (body?.email as string | undefined)?.toString().trim().toLowerCase();
+
+    if (!email) {
+      return NextResponse.json({ error: 'Email is required.' }, { status: 400 });
+    }
+
+    const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailPattern.test(email)) {
+      return NextResponse.json({ error: 'Please provide a valid email address.' }, { status: 400 });
+    }
+
+    const payload = {
+      email,
+      subscribedAt: new Date().toISOString(),
+      source: 'landing-page',
+    } satisfies Record<string, unknown>;
+
+    if (process.env.NEWSLETTER_WEBHOOK_URL) {
+      try {
+        const response = await fetch(process.env.NEWSLETTER_WEBHOOK_URL, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        });
+
+        if (!response.ok) {
+          throw new Error(`Webhook responded with ${response.status}`);
+        }
+      } catch (error) {
+        console.error('Failed to forward newsletter subscription', error);
+        return NextResponse.json(
+          { error: 'Unable to notify the team right now. Please email hello@variota.com to subscribe.' },
+          { status: 502 }
+        );
+      }
+    } else {
+      // TODO: Connect to marketing automation platform when available.
+      console.info('Newsletter subscription received', payload);
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Unexpected error while processing newsletter subscription', error);
+    return NextResponse.json(
+      { error: 'Unexpected error. Please try again later.' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,20 +11,19 @@ import { ThemeProvider } from '@/components/theme/theme-provider';
 
 export const metadata: Metadata = {
   title: {
-    default: 'Variota - No-Code Video Animation Platform',
+    default: 'Variota | Data-Driven Creative Automation for Retail & E-commerce',
     template: '%s | Variota',
   },
   description:
-    'Create stunning, data-driven video advertisements without coding. Variota empowers business professionals with an intuitive visual programming interface for animation creation.',
+    'Generate brand-safe images and videos from Excel/CSV using no-code logic. Localize by region and update thousands of assets in minutes. Join the pilot.',
   keywords: [
-    'video animation',
-    'no-code animation',
-    'visual programming',
-    'video advertisements',
-    'marketing videos',
-    'business automation',
-    'data-driven videos',
-    'node-based editor',
+    'creative automation',
+    'data-driven promo assets',
+    'batch image generation',
+    'video automation',
+    'regional pricing',
+    'no-code logic',
+    'retail promotions',
   ],
   authors: [{ name: 'Variota Team' }],
   creator: 'Variota',
@@ -34,23 +33,23 @@ export const metadata: Metadata = {
     type: 'website',
     locale: 'en_US',
     url: '/',
-    title: 'Variota - No-Code Video Animation Platform',
+    title: 'Variota | Data-Driven Creative Automation for Retail & E-commerce',
     description:
-      'Create stunning, data-driven video advertisements without coding. Variota empowers business professionals with an intuitive visual programming interface.',
+      'Generate brand-safe images and videos from Excel/CSV using no-code logic. Localize by region and update thousands of assets in minutes. Join the pilot.',
     siteName: 'Variota',
-    images: [
-      {
-        url: '/og-image.png',
-        width: 1200,
-        height: 630,
-        alt: 'Variota - No-Code Video Animation Platform',
-      },
-    ],
+      images: [
+        {
+          url: '/og-image.png',
+          width: 1200,
+          height: 630,
+          alt: 'Variota | Data-Driven Creative Automation for Retail & E-commerce',
+        },
+      ],
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'Variota - No-Code Video Animation Platform',
-    description: 'Create stunning, data-driven video advertisements without coding.',
+    title: 'Variota | Data-Driven Creative Automation for Retail & E-commerce',
+    description: 'Generate brand-safe images and videos from Excel/CSV using no-code logic.',
     images: ['/og-image.png'],
     creator: '@variota',
   },

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,397 +1,901 @@
 import Link from 'next/link';
-import { api, HydrateClient } from '@/trpc/server';
-import { createClient } from '@/utils/supabase/server';
 import { redirect } from 'next/navigation';
-import { CheckCircle2, Zap, Users, Shield, ArrowRight, Play, Star } from 'lucide-react';
+import {
+  ArrowRight,
+  CheckCircle2,
+  Database,
+  Globe2,
+  Layers,
+  LineChart,
+  Play,
+  ShieldCheck,
+  Sparkles,
+  Workflow,
+} from 'lucide-react';
+
 import Logo from '@/components/ui/logo';
 import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { HydrateClient, api } from '@/trpc/server';
+import { createClient } from '@/utils/supabase/server';
+
+import { EarlyAccessForm } from './_components/early-access-form';
+import { SubscribeForm } from './_components/subscribe-form';
 
 export default async function LandingPage() {
-  // Check if user is already authenticated
   const supabase = await createClient();
   const {
     data: { user },
   } = await supabase.auth.getUser();
 
-  // Redirect authenticated users to dashboard
   if (user) {
     redirect('/dashboard');
   }
 
   const hello = await api.post.hello({ text: 'from Variota' });
 
-  const features = [
+  const microBenefits = [
+    'No-code logic for colors, motion, sizes, and layouts tied to your data',
+    'Excel/CSV import to localize pricing, assortments, and messaging',
+    'Brand-locked templates that keep compliance copy intact',
+    'Batch-ready assets for social, marketplaces, in-store, and more',
+    'Instant regeneration whenever product data shifts',
+  ];
+
+  const personaWins = [
     {
-      icon: <Zap className="h-6 w-6" />,
-      title: 'No-Code Animation',
+      title: 'Marketing',
       description:
-        'Create stunning programmatic animations without writing a single line of code using our visual node-based editor.',
+        'Launch promotions faster, react to price swings instantly, and keep every channel aligned without waiting on production.',
     },
     {
-      icon: <Users className="h-6 w-6" />,
-      title: 'Business-Focused',
+      title: 'Creative & Design',
       description:
-        'Built specifically for marketing professionals and business teams to create data-driven video advertisements.',
+        'Automate repetitive variants with brand-locked templates so designers focus on storytelling instead of manual versioning.',
     },
     {
-      icon: <Shield className="h-6 w-6" />,
-      title: 'Enterprise Ready',
+      title: 'Merchandising',
       description:
-        'Secure, scalable, and reliable infrastructure with enterprise-grade authentication and data protection.',
+        'Reflect negotiated deals by category or region with a single data import and logic rules anyone can edit.',
+    },
+    {
+      title: 'Ad Ops & Performance',
+      description:
+        'Generate platform-ready variants for continuous testing and iteration without engineering bottlenecks.',
     },
   ];
 
-  const benefits = [
-    'Visual node-based programming interface',
-    'Server-side rendering for optimal quality',
-    'Real-time collaboration and workspace sharing',
-    'Advanced animation and timing controls',
-    'Export to multiple video formats',
-    'Integrated data sources and logic workspaces',
+  const problemPoints = [
+    'Frequent price and assortment changes across regions and channels',
+    "Manual tools don’t scale to hundreds or thousands of variants",
+    'Custom-coded pipelines require engineers and slow every iteration',
+    'Brand inconsistencies and compliance risks under deadline pressure',
+    'Rising labor costs and omnichannel demands',
   ];
+
+  const howItWorksSteps = [
+    {
+      title: 'Import data',
+      description:
+        'Upload Excel/CSV or connect a sheet. Map price, discount, region, category, color, size, and asset URLs in minutes.',
+    },
+    {
+      title: 'Build logic',
+      description:
+        'Use a no-code, node-based builder to define rules—like highlighting high-margin items or swapping layouts when inventory is low.',
+    },
+    {
+      title: 'Choose templates',
+      description:
+        'Start from brand-locked templates with dynamic fields, safe zones, and presets for every channel.',
+    },
+    {
+      title: 'Generate at scale',
+      description:
+        'Create image and video variants for all SKUs, regions, and channels in one batch run with cloud rendering.',
+    },
+    {
+      title: 'Review and publish',
+      description:
+        'Preview variants, route for approval, export packages, or deliver through feeds. Regenerate instantly when data changes.',
+    },
+  ];
+
+  const capabilityGroups = [
+    {
+      title: 'Data & Logic',
+      items: [
+        'Excel/CSV import, field mapping, and validation',
+        'No-code rules tied to product attributes and thresholds',
+        'Conditional animation, styling, and layouts based on data',
+        'Regional variants that respect currencies, copy, and disclosures',
+      ],
+    },
+    {
+      title: 'Creative Generation',
+      items: [
+        'Batch images and videos from a single source of truth',
+        'Aspect-ratio presets for social, ads, marketplaces, and in-store screens',
+        'Automatic naming, metadata, and tagging for every asset',
+        'Dynamic price formatting and multi-language text fields',
+      ],
+    },
+    {
+      title: 'Brand & Compliance',
+      items: [
+        'Brand-locked templates with fonts, colors, safe zones, and legal copy',
+        'Enforced disclosures and fine print per market',
+        'Localization guardrails for language, currency, and regulatory text',
+        'Audit-ready logs of who changed what and when',
+      ],
+    },
+    {
+      title: 'Workflow & Delivery',
+      items: [
+        'Roles and permissions for marketing, design, and merchandising teams',
+        'Approval steps, version history, and rollbacks',
+        'Error reporting, QA previews, and collaborative review',
+        'Scalable rendering queues with export packages and feed delivery roadmap',
+      ],
+    },
+  ];
+
+  const brandSafetyPoints = [
+    'Lock essential brand elements while still allowing controlled variation through logic rules.',
+    'Centralize brand kits across teams with fonts, colors, logos, and motion presets.',
+    'Automate regional legal text, disclosures, and pricing footnotes for every output.',
+    'Maintain traceability with approvals, version history, and audit logs.',
+  ];
+
+  const outcomes = [
+    'Compress promo production cycles from multi-day timelines to responsive updates.',
+    'Eliminate repetitive manual work so teams focus on campaigns, not versioning.',
+    'Keep every channel and region in sync the moment product data changes.',
+    'Enable rapid experimentation with effortless creative variants.',
+  ];
+
+  const useCases = [
+    'Weekly or bi-weekly promo cycles with regional pricing shifts',
+    'Large catalog updates for e-commerce sites and marketplaces',
+    'Marketplace thumbnails, banners, and featured stories generated in bulk',
+    'Social bursts with dynamic price badges, motion, and localized copy',
+    'In-store screens and printable flyers driven by the same source data',
+  ];
+
+  const audiences = [
+    'Marketing Managers and Growth Leaders',
+    'Creative Directors, Art Directors, and Designers',
+    'Merchandising and Category Managers',
+    'Ad Ops and Performance Marketing Teams',
+    'Digital, IT, and Innovation Leaders partnering with marketing',
+  ];
+
+  const comparisonPoints = [
+    {
+      title: 'Manual tools',
+      description:
+        'Great for a single hero asset but error-prone at volume. No data logic, limited localization, and every variant needs hand editing.',
+    },
+    {
+      title: 'Custom-coded automation',
+      description:
+        'Powerful yet dependent on engineers for setup and updates. Long lead times and expensive maintenance for every change request.',
+    },
+    {
+      title: 'Variota',
+      description:
+        'No-code, logic-first, data-to-creative engine for images and video. Operated by marketing teams with governance and brand safety built in.',
+    },
+  ];
+
+  const integrationsToday = [
+    'Excel/CSV uploads with validation and saved mappings',
+    'Google Sheets sync for shared merchandising data',
+    'Use existing product image URLs or DAM libraries',
+  ];
+
+  const integrationsRoadmap = [
+    'PIM, DAM, and CMS connectors',
+    'Marketplace and ad platform delivery',
+    'SSO and directory sync for enterprise governance',
+  ];
+
+  const pilotHighlights = {
+    intro:
+      'We’re partnering with promo-heavy retailers and e-commerce teams to validate workflows, governance, and outcomes.',
+    profile:
+      'Ideal pilot profile: multi-region pricing, frequent promo cycles, large SKU catalogs, and creative operations that need scale.',
+    provide:
+      'What we provide: onboarding support, template setup guidance, logic builder training, dedicated slack, and pilot incentives.',
+    ask: 'What we ask: sanitized sample data, 1–2 target templates, weekly working sessions, and candid feedback.',
+  };
+
+  const faqs = [
+    {
+      question: 'What makes Variota different from design tools or ad platforms?',
+      answer:
+        'Variota connects live product data and business rules directly into creative generation. Instead of manual layout work or limited ad templates, teams define logic once and produce governed assets across every channel.',
+    },
+    {
+      question: 'Can non-technical marketers use the logic builder?',
+      answer:
+        'Yes. The node-based builder uses plain-language rules, presets, and visual debugging so marketing, merchandising, and creative teams can own automation without code.',
+    },
+    {
+      question: 'How do you handle brand guidelines and approvals?',
+      answer:
+        'Templates lock critical brand elements while approvals, version history, and audit logs keep every change tracked. Legal copy blocks and safe zones are enforced automatically.',
+    },
+    {
+      question: 'Which data sources can I use? How are errors reported?',
+      answer:
+        'Start with Excel/CSV or Google Sheets. Field validation, error reports, and QA previews highlight any mismatches before generation.',
+    },
+    {
+      question: 'Can I generate both images and videos? Which formats are supported?',
+      answer:
+        'Yes. Batch render image and video assets with presets for social, marketplaces, digital signage, and more. Aspect ratios and duration rules are controlled through templates.',
+    },
+    {
+      question: 'How does localization work?',
+      answer:
+        'Localization rules manage languages, currencies, date formats, and legal text per market so teams launch compliant regional variants instantly.',
+    },
+    {
+      question: 'Do I need engineers to set it up?',
+      answer:
+        'No. Marketing and creative teams configure rules, while IT partners can assist with governance or data connections as needed.',
+    },
+    {
+      question: 'What about security and privacy?',
+      answer:
+        'Variota processes only the data you choose to upload, supports data deletion upon request, follows storage best practices, and has SSO and directory sync on the roadmap.',
+    },
+    {
+      question: 'What’s the pricing model?',
+      answer:
+        'Tiered subscriptions based on usage, seats, and integrations. Pilot and early access pricing is available once we confirm fit.',
+    },
+    {
+      question: 'How do pilots work? What’s expected from our team?',
+      answer:
+        'We co-design workflows with your team, deliver onboarding and training, and hold weekly check-ins. You provide feedback on outcomes so we can prioritize the roadmap together.',
+    },
+  ];
+
+  const accessibilityNotes = {
+    accessibility: [
+      'High-contrast CTAs, keyboard-friendly navigation, and consistent focus states',
+      'Alt text for visuals and captions for demo walkthroughs',
+      'Legible typography, responsive layouts, and comfortable tap targets on mobile',
+    ],
+    performance: [
+      'Optimized hero media with responsive loading',
+      'Lazy-load non-critical visuals and leverage CDN delivery',
+      'Compress demo assets to keep the experience fast under pressure',
+    ],
+    security: [
+      'Only process the data teams choose to upload and honor deletion requests',
+      'Follow hardened storage practices with scoped access controls',
+      'SSO and directory sync are on the roadmap for larger teams',
+    ],
+  };
 
   return (
     <HydrateClient>
       <div className="min-h-screen bg-[var(--surface-0)] text-[var(--text-primary)]">
-        {/* Header */}
-        <header className="sticky top-0 z-50 border-b border-[var(--border-primary)] bg-[var(--surface-1)]/80 backdrop-blur-sm">
+        <header className="sticky top-0 z-50 border-b border-[var(--border-primary)] bg-[var(--surface-1)]/90 backdrop-blur-xl">
           <div className="mx-auto flex max-w-7xl items-center justify-between px-6 py-4">
-            <div className="flex items-center gap-3">
-              <Link href="/dashboard" className="cursor-pointer">
-                <Logo className="h-16 w-64" />
-              </Link>
-            </div>
+            <Link href="/dashboard" className="flex items-center gap-3" aria-label="Variota home">
+              <Logo className="h-14 w-52" />
+            </Link>
 
-            <nav className="hidden items-center gap-8 md:flex">
-              <Link
-                href="#features"
-                className="text-[var(--text-secondary)] transition-colors hover:text-[var(--text-primary)]"
-              >
-                Features
+            <nav aria-label="Primary" className="hidden items-center gap-8 text-sm md:flex">
+              <Link href="#product" className="text-[var(--text-secondary)] transition-colors hover:text-[var(--text-primary)]">
+                Product
               </Link>
               <Link
-                href="#pricing"
+                href="#how-it-works"
                 className="text-[var(--text-secondary)] transition-colors hover:text-[var(--text-primary)]"
               >
-                Pricing
+                How It Works
               </Link>
               <Link
-                href="#about"
+                href="#use-cases"
                 className="text-[var(--text-secondary)] transition-colors hover:text-[var(--text-primary)]"
               >
-                About
+                Use Cases
+              </Link>
+              <Link href="#pilot" className="text-[var(--text-secondary)] transition-colors hover:text-[var(--text-primary)]">
+                Pilot
+              </Link>
+              <Link
+                href="#investors"
+                className="text-[var(--text-secondary)] transition-colors hover:text-[var(--text-primary)]"
+              >
+                Investors
               </Link>
             </nav>
 
             <div className="flex items-center gap-3">
-              <Link href="/login">
-                <Button variant="primary" size="sm">
+              <Link href="/login" className="hidden md:inline-flex">
+                <Button variant="ghost" size="sm">
                   Sign In
+                </Button>
+              </Link>
+              <Link href="#early-access">
+                <Button variant="primary" size="sm">
+                  Request Early Access
+                  <ArrowRight className="ml-2 h-4 w-4" aria-hidden="true" />
                 </Button>
               </Link>
             </div>
           </div>
         </header>
 
-        {/* Hero Section */}
-        <section className="mx-auto max-w-7xl px-6 py-20 text-center">
-          <div className="mx-auto max-w-4xl">
-            <h1 className="mb-8 text-5xl leading-tight font-extrabold tracking-tight md:text-7xl">
-              Create{' '}
-              <span className="bg-gradient-to-r from-[var(--node-animation)] to-[var(--accent-secondary)] bg-clip-text text-transparent">
-                Dynamic
-              </span>
-              <br />
-              Video Ads Without Code
-            </h1>
+        <main>
+          <section className="relative overflow-hidden">
+            <div className="mx-auto max-w-7xl px-6 py-24 sm:py-32">
+              <div className="grid gap-16 lg:grid-cols-[minmax(0,1.05fr)_minmax(0,0.95fr)] lg:items-center">
+                <div>
+                  <h1 className="text-balance text-4xl font-extrabold leading-tight tracking-tight sm:text-5xl md:text-6xl">
+                    Turn your product data into brand-safe images and videos—at scale, without code
+                  </h1>
+                  <p className="mt-6 max-w-2xl text-lg text-[var(--text-secondary)] sm:text-xl">
+                    Import Excel/CSV, set simple if-else rules, and generate thousands of localized assets in minutes. Update
+                    instantly when prices or assortments change across regions.
+                  </p>
 
-            <p className="mx-auto mb-12 max-w-3xl text-xl leading-relaxed text-[var(--text-secondary)]">
-              Variota empowers business professionals to build sophisticated, data-driven video
-              advertisements using an intuitive visual programming interface. No coding experience
-              required.
-            </p>
+                  <div className="mt-10 flex flex-col gap-4 sm:flex-row sm:items-center">
+                    <Link href="#pilot">
+                      <Button variant="primary" size="lg" className="w-full sm:w-auto">
+                        Apply for Pilot
+                        <ArrowRight className="ml-2 h-5 w-5" aria-hidden="true" />
+                      </Button>
+                    </Link>
+                    <Link href="#demo" className="w-full sm:w-auto">
+                      <Button variant="secondary" size="lg" className="w-full sm:w-auto">
+                        <Play className="mr-2 h-5 w-5" aria-hidden="true" /> Watch 2-minute demo
+                      </Button>
+                    </Link>
+                  </div>
 
-            <div className="mb-16 flex flex-col items-center justify-center gap-4 sm:flex-row">
-              <Link href="/login">
-                <Button variant="primary" size="lg" className="transform hover:scale-105">
-                  Start Creating Free <ArrowRight className="h-5 w-5" />
-                </Button>
-              </Link>
+                  <ul className="mt-12 grid gap-4 sm:grid-cols-2">
+                    {microBenefits.map((benefit) => (
+                      <li key={benefit} className="flex items-start gap-3 text-sm text-[var(--text-secondary)]">
+                        <CheckCircle2 className="mt-0.5 h-5 w-5 flex-shrink-0 text-[var(--accent-primary)]" aria-hidden="true" />
+                        <span>{benefit}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
 
-              <Link href="#demo">
-                <Button variant="glass" size="lg">
-                  <Play className="h-5 w-5" /> Watch Demo
-                </Button>
-              </Link>
-            </div>
-
-            {/* Social Proof */}
-            <div className="text-sm text-[var(--text-tertiary)]">
-              <p className="mb-4">Trusted by marketing teams at innovative companies</p>
-              <div className="flex items-center justify-center gap-2">
-                {Array.from({ length: 5 }, (_, i) => (
-                  <Star
-                    key={i}
-                    className="h-4 w-4 fill-[var(--warning-500)] text-[var(--warning-500)]"
-                  />
-                ))}
-                <span className="ml-2 text-[var(--text-secondary)]">
-                  4.9/5 from early access users
-                </span>
+                <figure className="glass-panel relative overflow-hidden rounded-[var(--radius-lg)] border border-[var(--glass-border)] p-8 shadow-glass-lg">
+                  <div className="space-y-6">
+                    <div className="rounded-[var(--radius-md)] border border-[var(--glass-border)] bg-[var(--surface-2)]/70 p-4">
+                      <div className="flex items-center gap-3 text-sm text-[var(--text-secondary)]">
+                        <Database className="h-5 w-5 text-[var(--accent-primary)]" aria-hidden="true" />
+                        <span>Product data import (prices, inventory, imagery)</span>
+                      </div>
+                    </div>
+                    <div className="rounded-[var(--radius-md)] border border-[var(--glass-border)] bg-[var(--surface-2)]/70 p-4">
+                      <div className="flex items-center gap-3 text-sm text-[var(--text-secondary)]">
+                        <Workflow className="h-5 w-5 text-[var(--accent-secondary)]" aria-hidden="true" />
+                        <span>No-code rule builder: highlight promos, localize copy, trigger animations</span>
+                      </div>
+                    </div>
+                    <div className="rounded-[var(--radius-md)] border border-[var(--glass-border)] bg-[var(--surface-2)]/70 p-4">
+                      <div className="flex items-center gap-3 text-sm text-[var(--text-secondary)]">
+                        <Layers className="h-5 w-5 text-[var(--node-animation)]" aria-hidden="true" />
+                        <span>Asset grid preview: localized images and video thumbnails ready to export</span>
+                      </div>
+                    </div>
+                  </div>
+                  <figcaption className="mt-6 text-sm text-[var(--text-tertiary)]">
+                    Visualizing the Variota flow: data in, logic applied, governed assets out.
+                  </figcaption>
+                </figure>
               </div>
             </div>
-          </div>
-        </section>
+          </section>
 
-        {/* Features Section */}
-        <section
-          id="features"
-          className="border-y border-[var(--border-primary)] bg-[var(--surface-1)]"
-        >
-          <div className="mx-auto max-w-7xl px-6 py-20">
-            <div className="mb-16 text-center">
-              <h2 className="mb-6 text-4xl font-bold">Powerful Features for Modern Marketing</h2>
-              <p className="mx-auto max-w-2xl text-xl text-[var(--text-secondary)]">
-                Everything you need to create professional, data-driven video content that converts.
+          <section className="border-y border-[var(--border-primary)] bg-[var(--surface-1)]/90">
+            <div className="mx-auto flex max-w-5xl flex-col gap-6 px-6 py-12 text-center text-sm text-[var(--text-secondary)] sm:flex-row sm:items-center sm:justify-center sm:text-base">
+              <span className="font-medium text-[var(--text-primary)]">Built with insights from retail leaders</span>
+              <span className="hidden h-4 w-px bg-[var(--border-primary)] sm:inline-block" aria-hidden="true" />
+              <span>Designed for promo-heavy retailers and e-commerce teams</span>
+              <span className="hidden h-4 w-px bg-[var(--border-primary)] sm:inline-block" aria-hidden="true" />
+              <span className="italic text-[var(--text-tertiary)]">“If one person can handle a full promo cycle in minutes, that’s a game-changer.”</span>
+            </div>
+          </section>
+
+          <section id="product" className="mx-auto max-w-7xl px-6 py-24 sm:py-28">
+            <div className="mb-12 max-w-3xl">
+              <h2 className="text-3xl font-bold sm:text-4xl">Role-specific wins without adding headcount</h2>
+              <p className="mt-4 text-lg text-[var(--text-secondary)]">
+                Variota equips every go-to-market role with governed automation so teams react to market shifts without sacrificing
+                brand or compliance.
               </p>
             </div>
-
-            <div className="mb-16 grid gap-8 md:grid-cols-3">
-              {features.map((feature, index) => (
-                <div
-                  key={index}
-                  className="rounded-lg border border-[var(--glass-border)] bg-[var(--glass-bg)] p-8 backdrop-blur-sm transition-colors hover:border-[var(--accent-primary)]"
-                >
-                  <div className="mb-6 flex h-12 w-12 items-center justify-center rounded-lg bg-[var(--accent-primary)] text-white">
-                    {feature.icon}
-                  </div>
-                  <h3 className="mb-4 text-xl font-semibold">{feature.title}</h3>
-                  <p className="leading-relaxed text-[var(--text-secondary)]">
-                    {feature.description}
-                  </p>
-                </div>
+            <div className="grid gap-6 md:grid-cols-2">
+              {personaWins.map((persona) => (
+                <Card key={persona.title} variant="glass" className="h-full p-6">
+                  <h3 className="text-xl font-semibold text-[var(--text-primary)]">{persona.title}</h3>
+                  <p className="mt-3 text-sm text-[var(--text-secondary)]">{persona.description}</p>
+                </Card>
               ))}
             </div>
+          </section>
 
-            {/* Benefits List */}
-            <div className="rounded-xl border border-[var(--border-primary)] bg-[var(--surface-2)] p-8">
-              <h3 className="mb-8 text-center text-2xl font-semibold">What You Get</h3>
-              <div className="grid gap-4 md:grid-cols-2">
-                {benefits.map((benefit, index) => (
-                  <div key={index} className="flex items-center gap-3">
-                    <CheckCircle2 className="h-5 w-5 flex-shrink-0 text-[var(--success-500)]" />
-                    <span className="text-[var(--text-secondary)]">{benefit}</span>
-                  </div>
+          <section className="border-y border-[var(--border-primary)] bg-[var(--surface-1)]/80">
+            <div className="mx-auto max-w-6xl px-6 py-24 sm:py-28">
+              <div className="max-w-3xl">
+                <h2 className="text-3xl font-bold sm:text-4xl">Manual production can’t keep up with modern promo cycles</h2>
+              </div>
+              <ul className="mt-10 grid gap-4 text-sm text-[var(--text-secondary)] md:grid-cols-2">
+                {problemPoints.map((point) => (
+                  <li key={point} className="flex items-start gap-3">
+                    <ArrowRight className="mt-1 h-4 w-4 text-[var(--accent-secondary)]" aria-hidden="true" />
+                    <span>{point}</span>
+                  </li>
+                ))}
+              </ul>
+              <p className="mt-10 max-w-2xl text-base text-[var(--text-secondary)]">
+                Teams need a logic-first engine that connects data to creative—fast, consistent, and non-technical.
+              </p>
+            </div>
+          </section>
+
+          <section id="how-it-works" className="mx-auto max-w-7xl px-6 py-24 sm:py-28">
+            <div className="max-w-3xl">
+              <h2 className="text-3xl font-bold sm:text-4xl">How Variota works</h2>
+              <p className="mt-4 text-lg text-[var(--text-secondary)]">
+                A five-step workflow that keeps marketing, merchandising, and creative teams in lockstep.
+              </p>
+            </div>
+            <div className="mt-14 grid gap-6 lg:grid-cols-5">
+              {howItWorksSteps.map((step, index) => (
+                <Card key={step.title} variant="glass" className="flex h-full flex-col p-6">
+                  <span className="text-sm font-medium text-[var(--accent-secondary)]">Step {index + 1}</span>
+                  <h3 className="mt-3 text-lg font-semibold text-[var(--text-primary)]">{step.title}</h3>
+                  <p className="mt-3 text-sm text-[var(--text-secondary)]">{step.description}</p>
+                </Card>
+              ))}
+            </div>
+            <div className="mt-12 flex flex-col gap-4 sm:flex-row sm:items-center">
+              <Link href="#demo">
+                <Button variant="primary" size="md">
+                  See it in a 2-minute demo
+                  <Play className="ml-2 h-4 w-4" aria-hidden="true" />
+                </Button>
+              </Link>
+              <p className="text-sm text-[var(--text-tertiary)]">
+                Prefer a walkthrough? Request a live session via the early access form below.
+              </p>
+            </div>
+          </section>
+
+          <section id="capabilities" className="border-y border-[var(--border-primary)] bg-[var(--surface-1)]/80">
+            <div className="mx-auto max-w-7xl px-6 py-24 sm:py-28">
+              <div className="max-w-3xl">
+                <h2 className="text-3xl font-bold sm:text-4xl">Capabilities</h2>
+                <p className="mt-4 text-lg text-[var(--text-secondary)]">
+                  Governed creative automation that brings data, logic, and production together.
+                </p>
+              </div>
+              <div className="mt-12 grid gap-8 lg:grid-cols-2">
+                {capabilityGroups.map((group) => (
+                  <Card key={group.title} variant="glass" className="p-6">
+                    <div className="flex items-center gap-3">
+                      {group.title === 'Data & Logic' && (
+                        <Database className="h-5 w-5 text-[var(--accent-primary)]" aria-hidden="true" />
+                      )}
+                      {group.title === 'Creative Generation' && (
+                        <Sparkles className="h-5 w-5 text-[var(--node-animation)]" aria-hidden="true" />
+                      )}
+                      {group.title === 'Brand & Compliance' && (
+                        <ShieldCheck className="h-5 w-5 text-[var(--accent-success)]" aria-hidden="true" />
+                      )}
+                      {group.title === 'Workflow & Delivery' && (
+                        <Workflow className="h-5 w-5 text-[var(--accent-secondary)]" aria-hidden="true" />
+                      )}
+                      <h3 className="text-lg font-semibold text-[var(--text-primary)]">{group.title}</h3>
+                    </div>
+                    <ul className="mt-4 space-y-3 text-sm text-[var(--text-secondary)]">
+                      {group.items.map((item) => (
+                        <li key={item} className="flex items-start gap-3">
+                          <CheckCircle2 className="mt-1 h-4 w-4 text-[var(--accent-primary)]" aria-hidden="true" />
+                          <span>{item}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </Card>
                 ))}
               </div>
             </div>
-          </div>
-        </section>
+          </section>
 
-        {/* Pricing Section */}
-        <section id="pricing" className="mx-auto max-w-7xl px-6 py-20">
-          <div className="mb-16 text-center">
-            <h2 className="mb-6 text-4xl font-bold">Simple, Transparent Pricing</h2>
-            <p className="text-xl text-[var(--text-secondary)]">Start free, scale as you grow</p>
-          </div>
-
-          <div className="mx-auto grid max-w-5xl gap-8 md:grid-cols-3">
-            {/* Free Tier */}
-            <div className="rounded-xl border border-[var(--glass-border)] bg-[var(--glass-bg)] p-8 backdrop-blur-sm">
-              <h3 className="mb-2 text-xl font-semibold">Starter</h3>
-              <div className="mb-6">
-                <span className="text-3xl font-bold">Free</span>
-                <span className="text-[var(--text-tertiary)]">/month</span>
-              </div>
-              <ul className="mb-8 space-y-3 text-[var(--text-secondary)]">
-                <li className="flex items-center gap-2">
-                  <CheckCircle2 className="h-4 w-4 text-[var(--success-500)]" />
-                  Up to 3 workspaces
-                </li>
-                <li className="flex items-center gap-2">
-                  <CheckCircle2 className="h-4 w-4 text-[var(--success-500)]" />
-                  Basic animation nodes
-                </li>
-                <li className="flex items-center gap-2">
-                  <CheckCircle2 className="h-4 w-4 text-[var(--success-500)]" />
-                  720p video export
-                </li>
-              </ul>
-              <Link
-                href="/login"
-                className="block w-full rounded-lg border border-[var(--border-primary)] px-6 py-3 text-center transition-colors hover:bg-[var(--surface-2)]"
-              >
-                Get Started
-              </Link>
-            </div>
-
-            {/* Pro Tier */}
-            <div className="relative rounded-xl border-2 border-[var(--accent-primary)] bg-[var(--glass-bg)] p-8 backdrop-blur-sm">
-              <div className="absolute -top-4 left-1/2 -translate-x-1/2 transform">
-                <span className="rounded-full bg-[var(--accent-primary)] px-4 py-1 text-sm font-medium text-white">
-                  Most Popular
-                </span>
-              </div>
-              <h3 className="mb-2 text-xl font-semibold">Professional</h3>
-              <div className="mb-6">
-                <span className="text-3xl font-bold">$29</span>
-                <span className="text-[var(--text-tertiary)]">/month</span>
-              </div>
-              <ul className="mb-8 space-y-3 text-[var(--text-secondary)]">
-                <li className="flex items-center gap-2">
-                  <CheckCircle2 className="h-4 w-4 text-[var(--success-500)]" />
-                  Unlimited workspaces
-                </li>
-                <li className="flex items-center gap-2">
-                  <CheckCircle2 className="h-4 w-4 text-[var(--success-500)]" />
-                  Advanced logic nodes
-                </li>
-                <li className="flex items-center gap-2">
-                  <CheckCircle2 className="h-4 w-4 text-[var(--success-500)]" />
-                  4K video export
-                </li>
-                <li className="flex items-center gap-2">
-                  <CheckCircle2 className="h-4 w-4 text-[var(--success-500)]" />
-                  Priority rendering
-                </li>
-              </ul>
-              <Link href="/login" className="block w-full">
-                <Button variant="primary" className="w-full">
-                  Start Pro Trial
-                </Button>
-              </Link>
-            </div>
-
-            {/* Enterprise Tier */}
-            <div className="rounded-xl border border-[var(--glass-border)] bg-[var(--glass-bg)] p-8 backdrop-blur-sm">
-              <h3 className="mb-2 text-xl font-semibold">Enterprise</h3>
-              <div className="mb-6">
-                <span className="text-3xl font-bold">Custom</span>
-              </div>
-              <ul className="mb-8 space-y-3 text-[var(--text-secondary)]">
-                <li className="flex items-center gap-2">
-                  <CheckCircle2 className="h-4 w-4 text-[var(--success-500)]" />
-                  Team collaboration
-                </li>
-                <li className="flex items-center gap-2">
-                  <CheckCircle2 className="h-4 w-4 text-[var(--success-500)]" />
-                  Custom integrations
-                </li>
-                <li className="flex items-center gap-2">
-                  <CheckCircle2 className="h-4 w-4 text-[var(--success-500)]" />
-                  Dedicated support
-                </li>
-                <li className="flex items-center gap-2">
-                  <CheckCircle2 className="h-4 w-4 text-[var(--success-500)]" />
-                  SLA guarantee
-                </li>
-              </ul>
-              <button className="w-full cursor-pointer rounded-lg border border-[var(--border-primary)] px-6 py-3 transition-colors hover:bg-[var(--surface-2)]">
-                Contact Sales
-              </button>
-            </div>
-          </div>
-        </section>
-
-        {/* CTA Section */}
-        <section className="border-t border-[var(--border-primary)] bg-gradient-to-r from-[var(--surface-1)] to-[var(--surface-2)]">
-          <div className="mx-auto max-w-4xl px-6 py-20 text-center">
-            <h2 className="mb-6 text-4xl font-bold">Ready to Transform Your Video Marketing?</h2>
-            <p className="mb-12 text-xl text-[var(--text-secondary)]">
-              Join hundreds of businesses already creating stunning video content with Variota.
-            </p>
-
-            <div className="flex flex-col justify-center gap-4 sm:flex-row">
-              <Link
-                href="/login"
-                className="inline-flex items-center justify-center gap-2 rounded-lg bg-gradient-to-r from-[var(--node-animation)] to-[var(--accent-secondary)] px-8 py-4 text-lg font-semibold text-white transition-all hover:opacity-90"
-              >
-                Start Your Free Account <ArrowRight className="h-5 w-5" />
-              </Link>
-            </div>
-
-            <div className="mt-12 text-center">
-              <p className="text-[var(--text-tertiary)]">
-                {hello ? hello.greeting : 'Welcome to the future of video creation'}
+          <section className="mx-auto max-w-6xl px-6 py-24 sm:py-28">
+            <div className="max-w-3xl">
+              <h2 className="text-3xl font-bold sm:text-4xl">Protect your brand at scale</h2>
+              <p className="mt-4 text-lg text-[var(--text-secondary)]">
+                Governance, compliance, and localization are first-class citizens across the Variota workflow.
               </p>
             </div>
-          </div>
-        </section>
+            <ul className="mt-10 space-y-4 text-sm text-[var(--text-secondary)]">
+              {brandSafetyPoints.map((point) => (
+                <li key={point} className="flex items-start gap-3">
+                  <ShieldCheck className="mt-0.5 h-5 w-5 text-[var(--accent-success)]" aria-hidden="true" />
+                  <span>{point}</span>
+                </li>
+              ))}
+            </ul>
+          </section>
 
-        {/* Footer */}
-        <footer className="border-t border-[var(--border-primary)] bg-[var(--surface-1)]">
-          <div className="mx-auto max-w-7xl px-6 py-12">
-            <div className="grid gap-8 md:grid-cols-4">
-              <div>
-                <div className="mb-4 flex items-center gap-3">
-                  <Logo className="h-12 w-48" />
-                </div>
-                <p className="text-sm text-[var(--text-secondary)]">
-                  No-code animation platform for creating dynamic, data-driven video advertisements.
-                </p>
+          <section className="border-y border-[var(--border-primary)] bg-[var(--surface-1)]/80">
+            <div className="mx-auto max-w-6xl px-6 py-24 sm:py-28">
+              <div className="max-w-3xl">
+                <h2 className="text-3xl font-bold sm:text-4xl">Ship more promotions, faster—without sacrificing brand or control</h2>
               </div>
+              <ul className="mt-10 grid gap-4 text-sm text-[var(--text-secondary)] md:grid-cols-2">
+                {outcomes.map((outcome) => (
+                  <li key={outcome} className="flex items-start gap-3">
+                    <LineChart className="mt-0.5 h-5 w-5 text-[var(--accent-secondary)]" aria-hidden="true" />
+                    <span>{outcome}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </section>
 
+          <section id="use-cases" className="mx-auto max-w-7xl px-6 py-24 sm:py-28">
+            <div className="grid gap-16 lg:grid-cols-2">
               <div>
-                <h4 className="mb-4 font-semibold">Product</h4>
-                <ul className="space-y-2 text-sm text-[var(--text-secondary)]">
-                  <li>
-                    <Link href="#features" className="hover:text-[var(--text-primary)]">
-                      Features
-                    </Link>
-                  </li>
-                  <li>
-                    <Link href="#pricing" className="hover:text-[var(--text-primary)]">
-                      Pricing
-                    </Link>
-                  </li>
-                  <li>
-                    <Link href="/login" className="hover:text-[var(--text-primary)]">
-                      Sign In
-                    </Link>
-                  </li>
+                <h2 className="text-3xl font-bold sm:text-4xl">Where Variota shines</h2>
+                <ul className="mt-8 space-y-4 text-sm text-[var(--text-secondary)]">
+                  {useCases.map((useCase) => (
+                    <li key={useCase} className="flex items-start gap-3">
+                      <Sparkles className="mt-0.5 h-5 w-5 text-[var(--node-animation)]" aria-hidden="true" />
+                      <span>{useCase}</span>
+                    </li>
+                  ))}
                 </ul>
               </div>
-
               <div>
-                <h4 className="mb-4 font-semibold">Company</h4>
-                <ul className="space-y-2 text-sm text-[var(--text-secondary)]">
-                  <li>
-                    <Link href="#about" className="hover:text-[var(--text-primary)]">
-                      About
-                    </Link>
-                  </li>
-                  <li>
-                    <Link href="#careers" className="hover:text-[var(--text-primary)]">
-                      Careers
-                    </Link>
-                  </li>
-                  <li>
-                    <Link href="#contact" className="hover:text-[var(--text-primary)]">
-                      Contact
-                    </Link>
-                  </li>
-                </ul>
-              </div>
-
-              <div>
-                <h4 className="mb-4 font-semibold">Legal</h4>
-                <ul className="space-y-2 text-sm text-[var(--text-secondary)]">
-                  <li>
-                    <Link href="/privacy" className="hover:text-[var(--text-primary)]">
-                      Privacy Policy
-                    </Link>
-                  </li>
-                  <li>
-                    <Link href="/terms" className="hover:text-[var(--text-primary)]">
-                      Terms of Service
-                    </Link>
-                  </li>
+                <h3 className="text-2xl font-semibold text-[var(--text-primary)]">Who it’s for</h3>
+                <ul className="mt-8 space-y-4 text-sm text-[var(--text-secondary)]">
+                  {audiences.map((audience) => (
+                    <li key={audience} className="flex items-start gap-3">
+                      <Globe2 className="mt-0.5 h-5 w-5 text-[var(--accent-primary)]" aria-hidden="true" />
+                      <span>{audience}</span>
+                    </li>
+                  ))}
                 </ul>
               </div>
             </div>
+          </section>
 
-            <div className="mt-8 border-t border-[var(--border-primary)] pt-8 text-center text-sm text-[var(--text-tertiary)]">
-              <p>&copy; 2024 Variota. All rights reserved.</p>
+          <section className="border-y border-[var(--border-primary)] bg-[var(--surface-1)]/85">
+            <div className="mx-auto max-w-6xl px-6 py-24 sm:py-28">
+              <div className="max-w-3xl">
+                <h2 className="text-3xl font-bold sm:text-4xl">Why Variota vs. alternatives?</h2>
+              </div>
+              <div className="mt-12 grid gap-6 md:grid-cols-3">
+                {comparisonPoints.map((comparison) => (
+                  <Card key={comparison.title} variant="glass" className="h-full p-6">
+                    <h3 className="text-xl font-semibold text-[var(--text-primary)]">{comparison.title}</h3>
+                    <p className="mt-4 text-sm text-[var(--text-secondary)]">{comparison.description}</p>
+                  </Card>
+                ))}
+              </div>
+            </div>
+          </section>
+
+          <section className="mx-auto max-w-6xl px-6 py-24 sm:py-28">
+            <div className="grid gap-12 lg:grid-cols-2">
+              <div>
+                <h2 className="text-3xl font-bold sm:text-4xl">Connect to your data and channels</h2>
+                <p className="mt-4 text-lg text-[var(--text-secondary)]">
+                  Bring Variota into your existing merchandising and creative stack. Tell us which integrations matter most during
+                  the pilot.
+                </p>
+              </div>
+              <div className="grid gap-6 md:grid-cols-2">
+                <Card variant="glass" className="p-6">
+                  <h3 className="text-lg font-semibold text-[var(--text-primary)]">Available today</h3>
+                  <ul className="mt-4 space-y-3 text-sm text-[var(--text-secondary)]">
+                    {integrationsToday.map((item) => (
+                      <li key={item} className="flex items-start gap-3">
+                        <CheckCircle2 className="mt-1 h-4 w-4 text-[var(--accent-primary)]" aria-hidden="true" />
+                        <span>{item}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </Card>
+                <Card variant="glass" className="p-6">
+                  <h3 className="text-lg font-semibold text-[var(--text-primary)]">On the roadmap</h3>
+                  <ul className="mt-4 space-y-3 text-sm text-[var(--text-secondary)]">
+                    {integrationsRoadmap.map((item) => (
+                      <li key={item} className="flex items-start gap-3">
+                        <ArrowRight className="mt-1 h-4 w-4 text-[var(--accent-secondary)]" aria-hidden="true" />
+                        <span>{item}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </Card>
+              </div>
+            </div>
+          </section>
+
+          <section id="pilot" className="border-y border-[var(--border-primary)] bg-[var(--surface-1)]/80">
+            <div className="mx-auto max-w-6xl px-6 py-24 sm:py-28">
+              <div className="max-w-3xl">
+                <h2 className="text-3xl font-bold sm:text-4xl">Join the pilot</h2>
+                <p className="mt-4 text-lg text-[var(--text-secondary)]">{pilotHighlights.intro}</p>
+              </div>
+              <div className="mt-10 grid gap-6 md:grid-cols-2">
+                <Card variant="glass" className="p-6">
+                  <h3 className="text-lg font-semibold text-[var(--text-primary)]">Ideal partners</h3>
+                  <p className="mt-3 text-sm text-[var(--text-secondary)]">{pilotHighlights.profile}</p>
+                </Card>
+                <Card variant="glass" className="p-6">
+                  <h3 className="text-lg font-semibold text-[var(--text-primary)]">What we provide</h3>
+                  <p className="mt-3 text-sm text-[var(--text-secondary)]">{pilotHighlights.provide}</p>
+                </Card>
+                <Card variant="glass" className="p-6 md:col-span-2">
+                  <h3 className="text-lg font-semibold text-[var(--text-primary)]">What we ask</h3>
+                  <p className="mt-3 text-sm text-[var(--text-secondary)]">{pilotHighlights.ask}</p>
+                </Card>
+              </div>
+              <div className="mt-10">
+                <Link href="#early-access">
+                  <Button variant="primary" size="md">
+                    Apply for Pilot
+                    <ArrowRight className="ml-2 h-4 w-4" aria-hidden="true" />
+                  </Button>
+                </Link>
+              </div>
+            </div>
+          </section>
+
+          <section id="demo" className="mx-auto max-w-6xl px-6 py-24 sm:py-28">
+            <div id="early-access" className="-mt-24 h-24 sm:-mt-32 sm:h-32" aria-hidden="true" />
+            <div className="grid gap-12 lg:grid-cols-[minmax(0,0.95fr)_minmax(0,1.05fr)] lg:items-center">
+              <div>
+                <h2 className="text-3xl font-bold sm:text-4xl">See Variota in action</h2>
+                <p className="mt-4 text-lg text-[var(--text-secondary)]">
+                  Request early access or book a live demo (15 minutes). Share your context and we’ll tailor the walkthrough.
+                </p>
+                <p className="mt-6 text-sm text-[var(--text-tertiary)]">We’ll reply within 2 business days.</p>
+              </div>
+              <Card variant="glass" className="p-6">
+                <EarlyAccessForm />
+              </Card>
+            </div>
+          </section>
+
+          <section id="investors" className="border-y border-[var(--border-primary)] bg-[var(--surface-1)]/85">
+            <div className="mx-auto grid max-w-6xl gap-12 px-6 py-24 sm:py-28 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)]">
+              <div>
+                <h2 className="text-3xl font-bold sm:text-4xl">Building the automation layer for retail creative</h2>
+                <p className="mt-4 text-lg text-[var(--text-secondary)]">
+                  Retail and e-commerce demand high-velocity, data-driven creative. Manual tools and custom-coded pipelines can’t
+                  keep pace with multi-region catalogs, compliance, and localization. Variota’s no-code, logic-first engine spans
+                  images and video with governance built in.
+                </p>
+              </div>
+              <div className="space-y-6 text-sm text-[var(--text-secondary)]">
+                <p>
+                  Early traction: pilot pipeline development with promo-heavy retailers, expert endorsements from merchandising
+                  leaders, and active design partners co-shaping automation workflows.
+                </p>
+                <p>
+                  Business model: tiered SaaS based on usage, seats, and integrations with enterprise options for governance and
+                  delivery.
+                </p>
+                <Link href="mailto:invest@variota.com" className="inline-flex">
+                  <Button variant="primary" size="md">
+                    Request investor brief
+                    <ArrowRight className="ml-2 h-4 w-4" aria-hidden="true" />
+                  </Button>
+                </Link>
+              </div>
+            </div>
+          </section>
+
+          <section id="faq" className="mx-auto max-w-6xl px-6 py-24 sm:py-28">
+            <div className="max-w-3xl">
+              <h2 className="text-3xl font-bold sm:text-4xl">FAQ</h2>
+            </div>
+            <div className="mt-10 space-y-6">
+              {faqs.map((faq) => (
+                <Card key={faq.question} variant="glass" className="p-6">
+                  <h3 className="text-lg font-semibold text-[var(--text-primary)]">{faq.question}</h3>
+                  <p className="mt-3 text-sm text-[var(--text-secondary)]">{faq.answer}</p>
+                </Card>
+              ))}
+            </div>
+          </section>
+
+          <section id="accessibility" className="border-y border-[var(--border-primary)] bg-[var(--surface-1)]/80">
+            <div className="mx-auto max-w-6xl px-6 py-24 sm:py-28">
+              <div className="max-w-3xl">
+                <h2 className="text-3xl font-bold sm:text-4xl">Accessibility, performance, and security</h2>
+                <p className="mt-4 text-lg text-[var(--text-secondary)]">
+                  Built for enterprise standards with inclusive design and resilient infrastructure.
+                </p>
+              </div>
+              <div className="mt-12 grid gap-6 md:grid-cols-3">
+                <Card variant="glass" className="p-6">
+                  <h3 className="text-lg font-semibold text-[var(--text-primary)]">Accessibility</h3>
+                  <ul className="mt-4 space-y-3 text-sm text-[var(--text-secondary)]">
+                    {accessibilityNotes.accessibility.map((item) => (
+                      <li key={item} className="flex items-start gap-3">
+                        <CheckCircle2 className="mt-1 h-4 w-4 text-[var(--accent-primary)]" aria-hidden="true" />
+                        <span>{item}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </Card>
+                <Card variant="glass" className="p-6">
+                  <h3 className="text-lg font-semibold text-[var(--text-primary)]">Performance</h3>
+                  <ul className="mt-4 space-y-3 text-sm text-[var(--text-secondary)]">
+                    {accessibilityNotes.performance.map((item) => (
+                      <li key={item} className="flex items-start gap-3">
+                        <CheckCircle2 className="mt-1 h-4 w-4 text-[var(--accent-primary)]" aria-hidden="true" />
+                        <span>{item}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </Card>
+                <Card variant="glass" className="p-6">
+                  <h3 className="text-lg font-semibold text-[var(--text-primary)]">Security & privacy</h3>
+                  <ul className="mt-4 space-y-3 text-sm text-[var(--text-secondary)]">
+                    {accessibilityNotes.security.map((item) => (
+                      <li key={item} className="flex items-start gap-3">
+                        <CheckCircle2 className="mt-1 h-4 w-4 text-[var(--accent-primary)]" aria-hidden="true" />
+                        <span>{item}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </Card>
+              </div>
+            </div>
+          </section>
+
+          <section className="mx-auto max-w-6xl px-6 py-24 sm:py-28">
+            <div className="rounded-[var(--radius-lg)] border border-[var(--glass-border)] bg-[var(--surface-1)]/80 p-10 text-center shadow-glass-lg">
+              <h2 className="text-3xl font-bold sm:text-4xl">Apply for pilot access</h2>
+              <p className="mt-4 text-lg text-[var(--text-secondary)]">
+                Ready to connect your product data to governed creative automation? Share your context and we’ll align on a pilot
+                path.
+              </p>
+              <div className="mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row">
+                <Link href="#early-access" className="inline-flex">
+                  <Button variant="primary" size="lg">
+                    Apply for Pilot
+                    <ArrowRight className="ml-2 h-5 w-5" aria-hidden="true" />
+                  </Button>
+                </Link>
+                <Link href="mailto:hello@variota.com" className="inline-flex">
+                  <Button variant="secondary" size="lg">
+                    Talk with our team
+                  </Button>
+                </Link>
+              </div>
+              <p className="mt-6 text-sm text-[var(--text-tertiary)]">
+                {hello ? hello.greeting : 'Welcome to the future of data-driven creative automation.'}
+              </p>
+            </div>
+          </section>
+        </main>
+
+        <footer className="border-t border-[var(--border-primary)] bg-[var(--surface-1)]/90">
+          <div className="mx-auto max-w-7xl px-6 py-16">
+            <div className="grid gap-12 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)]">
+              <div>
+                <Link href="/dashboard" className="flex items-center gap-3" aria-label="Variota logo">
+                  <Logo className="h-12 w-48" />
+                </Link>
+                <p className="mt-4 max-w-md text-sm text-[var(--text-secondary)]">
+                  Variota turns product data and business rules into brand-safe images and videos at scale. Subscribe for updates or
+                  request early access.
+                </p>
+                <div className="mt-6 max-w-sm">
+                  <SubscribeForm />
+                </div>
+              </div>
+              <div className="grid gap-10 sm:grid-cols-3">
+                <div>
+                  <h3 className="text-sm font-semibold uppercase tracking-wide text-[var(--text-tertiary)]">Navigate</h3>
+                  <ul className="mt-4 space-y-3 text-sm text-[var(--text-secondary)]">
+                    <li>
+                      <Link href="#product" className="hover:text-[var(--text-primary)]">
+                        Product
+                      </Link>
+                    </li>
+                    <li>
+                      <Link href="#how-it-works" className="hover:text-[var(--text-primary)]">
+                        How It Works
+                      </Link>
+                    </li>
+                    <li>
+                      <Link href="#use-cases" className="hover:text-[var(--text-primary)]">
+                        Use Cases
+                      </Link>
+                    </li>
+                    <li>
+                      <Link href="#pilot" className="hover:text-[var(--text-primary)]">
+                        Pilot
+                      </Link>
+                    </li>
+                    <li>
+                      <Link href="#investors" className="hover:text-[var(--text-primary)]">
+                        Investors
+                      </Link>
+                    </li>
+                    <li>
+                      <Link href="/login" className="hover:text-[var(--text-primary)]">
+                        Sign In
+                      </Link>
+                    </li>
+                  </ul>
+                </div>
+                <div>
+                  <h3 className="text-sm font-semibold uppercase tracking-wide text-[var(--text-tertiary)]">Company</h3>
+                  <ul className="mt-4 space-y-3 text-sm text-[var(--text-secondary)]">
+                    <li>
+                      <Link href="#product" className="hover:text-[var(--text-primary)]">
+                        About
+                      </Link>
+                    </li>
+                    <li>
+                      <Link href="mailto:hello@variota.com" className="hover:text-[var(--text-primary)]">
+                        Contact
+                      </Link>
+                    </li>
+                    <li>
+                      <Link href="#investors" className="hover:text-[var(--text-primary)]">
+                        Investors
+                      </Link>
+                    </li>
+                  </ul>
+                </div>
+                <div>
+                  <h3 className="text-sm font-semibold uppercase tracking-wide text-[var(--text-tertiary)]">Legal & social</h3>
+                  <ul className="mt-4 space-y-3 text-sm text-[var(--text-secondary)]">
+                    <li>
+                      <Link href="/privacy" className="hover:text-[var(--text-primary)]">
+                        Privacy Policy
+                      </Link>
+                    </li>
+                    <li>
+                      <Link href="/terms" className="hover:text-[var(--text-primary)]">
+                        Terms of Service
+                      </Link>
+                    </li>
+                    <li>
+                      <Link href="https://www.linkedin.com" target="_blank" rel="noreferrer" className="hover:text-[var(--text-primary)]">
+                        LinkedIn
+                      </Link>
+                    </li>
+                    <li>
+                      <Link href="mailto:hello@variota.com" className="hover:text-[var(--text-primary)]">
+                        Email us
+                      </Link>
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+            <div className="mt-12 flex flex-col items-center justify-between gap-4 border-t border-[var(--border-primary)] pt-6 text-xs text-[var(--text-tertiary)] sm:flex-row">
+              <p>&copy; {new Date().getFullYear()} Variota. All rights reserved.</p>
+              <Link href="#early-access" className="inline-flex">
+                <Button variant="primary" size="sm">
+                  Request Early Access
+                  <ArrowRight className="ml-2 h-4 w-4" aria-hidden="true" />
+                </Button>
+              </Link>
             </div>
           </div>
         </footer>


### PR DESCRIPTION
## Summary
- Rebuilt the marketing landing page to follow the pilot-focused content architecture with glass-theme components and updated CTAs
- Added reusable client forms for early-access requests and newsletter subscriptions that integrate with new API endpoints
- Refreshed site metadata to match the new positioning for data-driven retail creative automation

## Testing
- pnpm lint *(fails: missing required Supabase environment variables in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cdb9ae6e2c83228a5883bfa5ee067c