### PR TITLE
Refine workspace node visuals

### DIFF
--- a/src/components/workspace/nodes/animation-node.tsx
+++ b/src/components/workspace/nodes/animation-node.tsx
@@ -1,12 +1,20 @@
-// src/components/workspace/nodes/animation-node.tsx - Simplified single input/output ports
+// src/components/workspace/nodes/animation-node.tsx - Animation node UI
 'use client';
 
-import { Handle, Position, type NodeProps } from 'reactflow';
-import { Card, CardHeader, CardContent } from '@/components/ui/card';
-import { transformFactory } from '@/shared/registry/transforms';
-import { getNodeDefinition } from '@/shared/registry/registry-utils';
-import type { AnimationNodeData } from '@/shared/types/nodes';
+import type { NodeProps } from 'reactflow';
 import { Clapperboard } from 'lucide-react';
+
+import { getNodeDefinition } from '@/shared/registry/registry-utils';
+import { transformFactory } from '@/shared/registry/transforms';
+import type { AnimationNodeData } from '@/shared/types/nodes';
+
+import {
+  NodeCard,
+  NodeHeader,
+  NodePortIndicator,
+  getNodeCategoryLabel,
+  getNodeCategoryVisuals,
+} from './components/node-chrome';
 
 interface AnimationNodeProps extends NodeProps<AnimationNodeData> {
   onOpenTimeline?: () => void;
@@ -14,10 +22,18 @@ interface AnimationNodeProps extends NodeProps<AnimationNodeData> {
 
 export function AnimationNode({ data, selected, onOpenTimeline }: AnimationNodeProps) {
   const nodeDefinition = getNodeDefinition('animation');
+  const category = nodeDefinition?.execution.category;
+  const visuals = getNodeCategoryVisuals(category);
+  const categoryLabel = getNodeCategoryLabel(category);
+
+  const trackCount = data.tracks?.length ?? 0;
+  const uniqueTypes = [...new Set(data.tracks?.map((track) => track.type) ?? [])];
 
   const handleDoubleClick = () => {
-    if (onOpenTimeline) return onOpenTimeline();
-    // Fallback: navigate to dedicated timeline editor page preserving workspace
+    if (onOpenTimeline) {
+      onOpenTimeline();
+      return;
+    }
     const params = new URLSearchParams(window.location.search);
     const ws = params.get('workspace');
     const url = new URL(window.location.href);
@@ -27,83 +43,72 @@ export function AnimationNode({ data, selected, onOpenTimeline }: AnimationNodeP
     window.history.pushState({}, '', url.toString());
   };
 
-  const trackCount = data.tracks?.length || 0;
-  const trackTypes = data.tracks?.map((t) => t.type) || [];
-  const uniqueTypes = [...new Set(trackTypes)];
-
-  const handleClass = 'bg-[var(--node-animation)]';
+  const trackColors = transformFactory.getTrackColors?.() ?? {};
+  const trackIcons = transformFactory.getTrackIcons?.() ?? {};
 
   return (
-    <Card
-      selected={selected}
-      className="min-w-[var(--node-min-width)] cursor-pointer p-[var(--card-padding)] transition-all hover:bg-[var(--surface-interactive)]"
-      onDoubleClick={handleDoubleClick}
-    >
-      {/* Single input port */}
+    <NodeCard selected={selected} className="cursor-pointer" onDoubleClick={handleDoubleClick}>
       {nodeDefinition?.ports.inputs.map((port) => (
-        <Handle
+        <NodePortIndicator
           key={port.id}
-          type="target"
-          position={Position.Left}
           id={port.id}
-          className={`h-3 w-3 ${handleClass} !border-2 !border-[var(--text-primary)]`}
-          style={{ top: `50%` }}
+          side="left"
+          type="target"
+          top="50%"
+          label="Objects to animate"
+          description="Connect the elements you want to drive with keyframes."
+          handleClassName={visuals.handle}
+          accent={category}
         />
       ))}
 
-      <CardHeader className="p-0 pb-[var(--space-3)]">
-        <div className="flex items-center justify-between">
-          <div className="flex min-w-0 flex-1 items-center gap-[var(--space-2)]">
-            <div className="flex h-6 w-6 items-center justify-center rounded bg-[var(--node-animation)] text-[var(--text-primary)]">
-              <Clapperboard size={12} />
-            </div>
-            <span className="font-semibold text-[var(--text-primary)]">
-              {data.identifier.displayName}
-            </span>
-          </div>
-          <div className="text-xs text-[var(--text-tertiary)]">{data.duration}s</div>
-        </div>
-      </CardHeader>
+      <NodeHeader
+        icon={<Clapperboard size={14} />}
+        title={data.identifier.displayName}
+        accentClassName={visuals.iconBg}
+        subtitle={categoryLabel}
+        meta={<span className="text-xs text-[var(--text-secondary)]">{data.duration}s</span>}
+      />
 
-      <CardContent className="space-y-[var(--space-2)] p-0">
+      <div className="space-y-[var(--space-2)] text-xs text-[var(--text-secondary)]">
         <div className="flex items-center justify-between">
-          <span className="text-xs text-[var(--text-secondary)]">Tracks:</span>
-          <span className="text-xs font-medium text-[var(--text-primary)]">{trackCount}</span>
+          <span>Tracks</span>
+          <span className="font-medium text-[var(--text-primary)]">{trackCount}</span>
         </div>
-
-        {trackCount > 0 && (
-          <div className="flex flex-wrap gap-1">
+        {trackCount > 0 ? (
+          <div className="flex flex-wrap gap-[var(--space-1)]">
             {uniqueTypes.map((type) => (
               <span
                 key={type}
-                className={`rounded-[var(--radius-sharp)] px-[var(--space-2)] py-[var(--space-1)] text-xs ${transformFactory.getTrackColors()[type] ?? 'bg-[var(--surface-2)]'} text-[var(--text-primary)]`}
+                className={`rounded-full px-[var(--space-2)] py-[var(--space-1)] text-[11px] ${trackColors[type] ?? 'bg-[var(--surface-2)]'} text-[var(--text-primary)]`}
               >
-                {transformFactory.getTrackIcons()[type] ?? '●'} {type}
+                {trackIcons[type] ?? '●'} {type}
               </span>
             ))}
           </div>
+        ) : (
+          <div className="rounded border border-dashed border-[var(--border-primary)] px-[var(--space-3)] py-[var(--space-2)] text-center text-[11px] text-[var(--text-tertiary)]">
+            No keyframes yet—double-click to open the timeline.
+          </div>
         )}
-
-        {trackCount === 0 && (
-          <div className="py-2 text-center text-xs text-[var(--text-tertiary)]">No tracks</div>
-        )}
-
-        <div className="pt-1 text-[10px] text-[var(--text-tertiary)]">
-          Variables can be bound in the timeline editor
+        <div className="rounded border border-dashed border-[var(--border-primary)] px-[var(--space-3)] py-[var(--space-2)] text-[11px]">
+          Manage keyframes, easing, and variable bindings from the timeline editor.
         </div>
-      </CardContent>
+      </div>
 
-      {/* Single output port */}
       {nodeDefinition?.ports.outputs.map((port) => (
-        <Handle
+        <NodePortIndicator
           key={port.id}
-          type="source"
-          position={Position.Right}
           id={port.id}
-          className={`h-3 w-3 ${handleClass} !border-2 !border-[var(--text-primary)]`}
-          style={{ top: `50%` }}
+          side="right"
+          type="source"
+          top="50%"
+          label="Animated objects"
+          description="Outputs the objects with their keyframes applied."
+          handleClassName={visuals.handle}
+          accent={category}
         />
       ))}
-    </Card>
+    </NodeCard>
   );
 }

--- a/src/components/workspace/nodes/batch-node.tsx
+++ b/src/components/workspace/nodes/batch-node.tsx
@@ -1,15 +1,24 @@
+// src/components/workspace/nodes/batch-node.tsx - Batch tagging node UI
 'use client';
 
 import React from 'react';
-import { Handle, Position } from 'reactflow';
+import type { NodeProps } from 'reactflow';
+import { Tag } from 'lucide-react';
+
 import { useWorkspace } from '@/components/workspace/workspace-context';
 import { Input } from '@/components/ui/input';
-
-import { Card, CardHeader, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Modal } from '@/components/ui/modal';
 import { getNodeDefinition } from '@/shared/registry/registry-utils';
 import type { NodeData } from '@/shared/types/nodes';
+
+import {
+  NodeCard,
+  NodeHeader,
+  NodePortIndicator,
+  getNodeCategoryLabel,
+  getNodeCategoryVisuals,
+} from './components/node-chrome';
 
 export function BatchNode({ id }: { id: string }) {
   const { state, updateFlow } = useWorkspace();
@@ -28,67 +37,64 @@ export function BatchNode({ id }: { id: string }) {
   const [localInput, setLocalInput] = React.useState('');
 
   const nodeDefinition = getNodeDefinition('batch');
-  const handleClass = 'bg-[var(--node-logic)]';
+  const category = nodeDefinition?.execution.category;
+  const visuals = getNodeCategoryVisuals(category);
+  const categoryLabel = getNodeCategoryLabel(category);
 
   return (
-    <Card
-      className="min-w-[var(--node-min-width)] cursor-pointer p-[var(--card-padding)]"
-      onDoubleClick={() => setOpen(true)}
-    >
+    <NodeCard className="cursor-pointer" onDoubleClick={() => setOpen(true)}>
       {nodeDefinition?.ports.inputs.map((port) => (
-        <Handle
+        <NodePortIndicator
           key={port.id}
-          type="target"
-          position={Position.Left}
           id={port.id}
-          className={`h-3 w-3 ${handleClass} !border-2 !border-[var(--text-primary)]`}
-          style={{ top: `50%` }}
-          onDoubleClick={(e) => e.stopPropagation()}
+          side="left"
+          type="target"
+          top="50%"
+          label="Incoming stream"
+          description="Objects passing through will receive tags."
+          handleClassName={visuals.handle}
+          accent={category}
+          onHandleDoubleClick={(event) => event.stopPropagation()}
         />
       ))}
 
-      <CardHeader className="p-0 pb-[var(--space-3)]">
-        <div className="flex items-center gap-[var(--space-2)]">
-          <div className="flex h-6 w-6 items-center justify-center rounded bg-[var(--node-logic)] text-[var(--text-primary)]">
-            <span role="img" aria-label="batch">
-              🏷️
-            </span>
-          </div>
-          <span className="font-semibold text-[var(--text-primary)]">
-            {node?.data?.identifier?.displayName ?? 'Batch'}
-          </span>
-          <span className="ml-auto text-[10px] text-[var(--text-secondary)]">
-            {keys.length} keys
-          </span>
-        </div>
-      </CardHeader>
+      <NodeHeader
+        icon={<Tag size={14} />}
+        title={node?.data?.identifier?.displayName ?? 'Batch'}
+        accentClassName={visuals.iconBg}
+        subtitle={categoryLabel}
+        meta={<span className="text-xs text-[var(--text-secondary)]">{keys.length} keys</span>}
+      />
 
-      <CardContent className="space-y-2 p-0">
-        <div className="flex items-center gap-[var(--space-2)]">
-          <Button variant="secondary" onClick={() => setOpen(true)}>
-            Keys
-          </Button>
-          <div className="text-[10px] text-[var(--text-tertiary)]">Manage keys</div>
+      <div className="space-y-[var(--space-2)] text-xs text-[var(--text-secondary)]">
+        <Button variant="secondary" size="sm" onClick={() => setOpen(true)}>
+          Manage keys
+        </Button>
+        <div className="rounded border border-dashed border-[var(--border-primary)] px-[var(--space-3)] py-[var(--space-2)] text-[11px]">
+          Tags let you batch render subsets of your scene without duplicating nodes.
         </div>
-      </CardContent>
+      </div>
 
       {nodeDefinition?.ports.outputs.map((port) => (
-        <Handle
+        <NodePortIndicator
           key={port.id}
-          type="source"
-          position={Position.Right}
           id={port.id}
-          className={`h-3 w-3 ${handleClass} !border-2 !border-[var(--text-primary)]`}
-          style={{ top: `50%` }}
-          onDoubleClick={(e) => e.stopPropagation()}
+          side="right"
+          type="source"
+          top="50%"
+          label="Tagged stream"
+          description="Outputs the same objects with batch metadata attached."
+          handleClassName={visuals.handle}
+          accent={category}
+          onHandleDoubleClick={(event) => event.stopPropagation()}
         />
       ))}
 
       {open ? (
-        <Modal isOpen={open} onClose={() => setOpen(false)} title="Batch Keys" size="sm">
-          <div className="p-[var(--space-4)]">
-            <div className="mb-[var(--space-2)] text-[12px] text-[var(--text-secondary)]">
-              Add or remove keys
+        <Modal isOpen={open} onClose={() => setOpen(false)} title="Batch keys" size="sm">
+          <div className="space-y-[var(--space-3)] p-[var(--space-4)] text-xs text-[var(--text-secondary)]">
+            <div className="text-[11px] text-[var(--text-tertiary)]">
+              Add or remove keys. Updates apply immediately.
             </div>
             <div className="flex gap-[var(--space-2)]">
               <Input
@@ -98,11 +104,9 @@ export function BatchNode({ id }: { id: string }) {
               />
               <Button
                 onClick={() => {
-                  const v = localInput.trim();
-                  if (!v) return;
-                  if (keys.includes(v)) return; // prevent duplicates
-                  const nextKeys = [...keys, v];
-                  // Autosave like layer modal: update flow immediately
+                  const value = localInput.trim();
+                  if (!value || keys.includes(value)) return;
+                  const nextKeys = [...keys, value];
                   updateFlow({
                     nodes: state.flow.nodes.map((n) =>
                       n.id !== id
@@ -116,7 +120,6 @@ export function BatchNode({ id }: { id: string }) {
                           }
                     ),
                   });
-                  // Notify FlowEditorTab to sync its local nodes to prevent snap-back overwrite
                   if (typeof window !== 'undefined') {
                     window.dispatchEvent(
                       new CustomEvent('batch-keys-updated', {
@@ -134,16 +137,16 @@ export function BatchNode({ id }: { id: string }) {
               </Button>
             </div>
 
-            <div className="mt-[var(--space-3)] space-y-[var(--space-2)]">
+            <div className="space-y-[var(--space-2)]">
               {keys.length === 0 ? (
-                <div className="text-[12px] text-[var(--text-tertiary)]">No keys yet.</div>
+                <div className="text-[11px] text-[var(--text-tertiary)]">No keys yet.</div>
               ) : (
                 keys.map((k) => (
                   <div
                     key={k}
-                    className="flex items-center justify-between rounded border border-[var(--border)] px-[var(--space-2)] py-[var(--space-1)]"
+                    className="flex items-center justify-between rounded border border-[var(--border-primary)] px-[var(--space-2)] py-[var(--space-1)]"
                   >
-                    <div className="text-[12px]">{k}</div>
+                    <div>{k}</div>
                     <Button
                       variant="ghost"
                       size="sm"
@@ -180,13 +183,9 @@ export function BatchNode({ id }: { id: string }) {
                 ))
               )}
             </div>
-
-            <div className="mt-[var(--space-3)] text-right text-[10px] text-[var(--text-tertiary)]">
-              Changes update your workspace immediately. Use Save to persist.
-            </div>
           </div>
         </Modal>
       ) : null}
-    </Card>
+    </NodeCard>
   );
 }

--- a/src/components/workspace/nodes/canvas-node.tsx
+++ b/src/components/workspace/nodes/canvas-node.tsx
@@ -1,21 +1,35 @@
-// src/components/workspace/nodes/canvas-node.tsx
+// src/components/workspace/nodes/canvas-node.tsx - Canvas styling node UI
 'use client';
 
-import { Handle, Position, type NodeProps } from 'reactflow';
-import { Card, CardHeader, CardContent } from '@/components/ui/card';
-import { getNodeDefinition } from '@/shared/registry/registry-utils';
-import type { CanvasNodeData } from '@/shared/types/nodes';
+import type { NodeProps } from 'reactflow';
 import { Palette } from 'lucide-react';
 
-type CanvasNodeProps = NodeProps<CanvasNodeData> & {
+import { getNodeDefinition } from '@/shared/registry/registry-utils';
+import type { CanvasNodeData } from '@/shared/types/nodes';
+
+import {
+  NodeCard,
+  NodeHeader,
+  NodePortIndicator,
+  getNodeCategoryLabel,
+  getNodeCategoryVisuals,
+} from './components/node-chrome';
+
+interface CanvasNodeProps extends NodeProps<CanvasNodeData> {
   onOpenCanvas?: () => void;
-};
+}
 
 export function CanvasNode({ data, selected, onOpenCanvas }: CanvasNodeProps) {
   const nodeDefinition = getNodeDefinition('canvas');
+  const category = nodeDefinition?.execution.category;
+  const visuals = getNodeCategoryVisuals(category);
+  const categoryLabel = getNodeCategoryLabel(category);
 
   const handleDoubleClick = () => {
-    if (onOpenCanvas) return onOpenCanvas();
+    if (onOpenCanvas) {
+      onOpenCanvas();
+      return;
+    }
     const params = new URLSearchParams(window.location.search);
     const ws = params.get('workspace');
     const url = new URL(window.location.href);
@@ -25,53 +39,58 @@ export function CanvasNode({ data, selected, onOpenCanvas }: CanvasNodeProps) {
     window.history.pushState({}, '', url.toString());
   };
 
-  const handleClass = 'bg-[var(--node-geometry)]';
-
   return (
-    <Card
-      selected={selected}
-      className="min-w-[var(--node-min-width)] cursor-pointer p-[var(--card-padding)] transition-all hover:bg-[var(--surface-interactive)]"
-      onDoubleClick={handleDoubleClick}
-    >
+    <NodeCard selected={selected} className="cursor-pointer" onDoubleClick={handleDoubleClick}>
       {nodeDefinition?.ports.inputs.map((port) => (
-        <Handle
+        <NodePortIndicator
           key={port.id}
+          id={port.id}
+          side="left"
           type="target"
-          position={Position.Left}
-          id={port.id}
-          className={`h-3 w-3 ${handleClass} !border-2 !border-[var(--text-primary)]`}
-          style={{ top: `50%` }}
+          top="50%"
+          label="Objects to style"
+          description="Connect the items you want to adjust on the canvas."
+          handleClassName={visuals.handle}
+          accent={category}
         />
       ))}
-      {nodeDefinition?.ports.outputs.map((port, idx) => (
-        <Handle
+
+      <NodeHeader
+        icon={<Palette size={14} />}
+        title={data?.identifier?.displayName ?? 'Canvas'}
+        accentClassName={visuals.iconBg}
+        subtitle={categoryLabel}
+      />
+
+      <div className="space-y-[var(--space-2)] text-xs text-[var(--text-secondary)]">
+        <div className="flex items-center justify-between">
+          <span>Opacity</span>
+          <span className="font-medium text-[var(--text-primary)]">{data.opacity ?? 1}</span>
+        </div>
+        <div className="flex items-center justify-between">
+          <span>Fill color</span>
+          <span className="font-medium text-[var(--text-primary)]">
+            {data.fillColor ?? '#ffffff'}
+          </span>
+        </div>
+        <div className="rounded border border-dashed border-[var(--border-primary)] px-[var(--space-3)] py-[var(--space-2)] text-[11px]">
+          Double-click to adjust transforms and layer order in the canvas panel.
+        </div>
+      </div>
+
+      {nodeDefinition?.ports.outputs.map((port) => (
+        <NodePortIndicator
           key={port.id}
-          type="source"
-          position={Position.Right}
           id={port.id}
-          className={`h-3 w-3 ${handleClass} !border-2 !border-[var(--text-primary)]`}
-          style={{ top: `${50 + idx * 16}%` }}
+          side="right"
+          type="source"
+          top="50%"
+          label="Styled objects"
+          description="Outputs the objects with canvas styling applied."
+          handleClassName={visuals.handle}
+          accent={category}
         />
       ))}
-
-      <CardHeader className="p-0 pb-[var(--space-3)]">
-        <div className="flex items-center gap-[var(--space-2)]">
-          <div className="flex h-6 w-6 items-center justify-center rounded bg-[var(--node-geometry)] text-[var(--text-primary)]">
-            <Palette size={12} />
-          </div>
-          <div className="min-w-0 flex-1">
-            <div className="truncate font-semibold text-[var(--text-primary)]">
-              {data?.identifier?.displayName ?? 'Canvas'}
-            </div>
-          </div>
-        </div>
-      </CardHeader>
-
-      <CardContent className="space-y-2 p-0 text-xs text-[var(--text-secondary)]">
-        <div className="pt-1 text-[10px] text-[var(--text-tertiary)]">
-          Double-click to edit in Canvas tab
-        </div>
-      </CardContent>
-    </Card>
+    </NodeCard>
   );
 }

--- a/src/components/workspace/nodes/circle-node.tsx
+++ b/src/components/workspace/nodes/circle-node.tsx
@@ -1,46 +1,60 @@
-// src/components/workspace/nodes/circle-node.tsx - Simplified single output port
+// src/components/workspace/nodes/circle-node.tsx - Circular geometry node UI
 'use client';
 
-import { Handle, Position, type NodeProps } from 'reactflow';
-import { Card, CardHeader, CardContent } from '@/components/ui/card';
+import type { NodeProps } from 'reactflow';
+import { Circle as CircleIcon } from 'lucide-react';
+
 import { getNodeDefinition } from '@/shared/registry/registry-utils';
 import type { CircleNodeData } from '@/shared/types/nodes';
-import { Circle as CircleIcon } from 'lucide-react';
+
+import {
+  NodeCard,
+  NodeHeader,
+  NodePortIndicator,
+  getNodeCategoryLabel,
+  getNodeCategoryVisuals,
+} from './components/node-chrome';
 
 export function CircleNode({ data, selected }: NodeProps<CircleNodeData>) {
   const nodeDefinition = getNodeDefinition('circle');
+  const category = nodeDefinition?.execution.category;
+  const visuals = getNodeCategoryVisuals(category);
+  const categoryLabel = getNodeCategoryLabel(category);
+  const radius = data.radius ?? (nodeDefinition?.defaults.radius as number) ?? 50;
 
   return (
-    <Card selected={selected} className="min-w-[var(--node-min-width)] p-[var(--card-padding)]">
-      <CardHeader className="p-0 pb-[var(--space-3)]">
-        <div className="flex items-center gap-[var(--space-2)]">
-          <div
-            className="flex h-6 w-6 items-center justify-center rounded text-[var(--text-primary)]"
-            style={{ backgroundColor: '#4444ff' }} // Canvas default
-          >
-            <CircleIcon size={12} />
-          </div>
-          <span className="font-semibold text-[var(--text-primary)]">
-            {data.identifier.displayName}
-          </span>
+    <NodeCard selected={selected}>
+      <NodeHeader
+        icon={<CircleIcon size={14} />}
+        title={data.identifier.displayName}
+        accentClassName={visuals.iconBg}
+        subtitle={categoryLabel}
+        meta={<span className="text-xs text-[var(--text-secondary)]">Radius {radius}px</span>}
+      />
+
+      <div className="space-y-[var(--space-2)] text-xs text-[var(--text-secondary)]">
+        <div className="flex items-center justify-between">
+          <span>Edge softness</span>
+          <span className="font-medium text-[var(--text-primary)]">Perfectly round</span>
         </div>
-      </CardHeader>
+        <div className="rounded border border-dashed border-[var(--border-primary)] px-[var(--space-3)] py-[var(--space-2)] text-[11px]">
+          Emits a smooth circle that pairs well with gradient fills, masks, or duplication nodes.
+        </div>
+      </div>
 
-      <CardContent className="space-y-1 p-0 text-xs text-[var(--text-secondary)]">
-        <div>Radius: {data.radius || 50}px</div>
-      </CardContent>
-
-      {/* Single output port */}
       {nodeDefinition?.ports.outputs.map((port) => (
-        <Handle
+        <NodePortIndicator
           key={port.id}
-          type="source"
-          position={Position.Right}
           id={port.id}
-          className={`h-3 w-3 !border-2 !border-[var(--text-primary)] bg-[var(--node-geometry)]`}
-          style={{ top: `50%` }}
+          side="right"
+          type="source"
+          top="50%"
+          label="Shape output"
+          description="Passes the circle forward for styling or animation."
+          handleClassName={visuals.handle}
+          accent={category}
         />
       ))}
-    </Card>
+    </NodeCard>
   );
 }

--- a/src/components/workspace/nodes/compare-node.tsx
+++ b/src/components/workspace/nodes/compare-node.tsx
@@ -1,14 +1,26 @@
 // src/components/workspace/nodes/compare-node.tsx - Compare logic node
+
 'use client';
 
-import { Handle, Position, type NodeProps } from 'reactflow';
-import { Card, CardHeader, CardContent } from '@/components/ui/card';
+import type { NodeProps } from 'reactflow';
+import { Equal } from 'lucide-react';
+
 import { getNodeDefinition } from '@/shared/registry/registry-utils';
 import type { CompareNodeData } from '@/shared/types/nodes';
-import { Equal } from 'lucide-react';
+
+import {
+  NodeCard,
+  NodeHeader,
+  NodePortIndicator,
+  getNodeCategoryLabel,
+  getNodeCategoryVisuals,
+} from './components/node-chrome';
 
 export function CompareNode({ data, selected }: NodeProps<CompareNodeData>) {
   const nodeDefinition = getNodeDefinition('compare');
+  const category = nodeDefinition?.execution.category;
+  const visuals = getNodeCategoryVisuals(category);
+  const categoryLabel = getNodeCategoryLabel(category);
 
   const getOperatorSymbol = () => {
     switch (data.operator) {
@@ -44,71 +56,71 @@ export function CompareNode({ data, selected }: NodeProps<CompareNodeData>) {
     }
   };
 
-  const handleClass = 'bg-[var(--node-logic)]';
-
   return (
-    <Card selected={selected} className="min-w-[var(--node-min-width)] p-[var(--card-padding)]">
-      {/* Input ports */}
+    <NodeCard selected={selected}>
       {nodeDefinition?.ports.inputs.map((port, index) => (
-        <Handle
+        <NodePortIndicator
           key={port.id}
-          type="target"
-          position={Position.Left}
           id={port.id}
-          className={`h-3 w-3 ${handleClass} !border-2 !border-[var(--text-primary)]`}
-          style={{ top: `${35 + index * 30}%` }}
+          side="left"
+          type="target"
+          top={`${35 + index * 30}%`}
+          label={index === 0 ? 'First value' : 'Second value'}
+          description={
+            index === 0
+              ? 'Connect the value you want to test.'
+              : 'Connect what you want to compare against.'
+          }
+          handleClassName={visuals.handle}
+          accent={category}
+          icon={
+            <span className="text-[0.65rem] leading-none font-semibold">
+              {index === 0 ? 'A' : 'B'}
+            </span>
+          }
         />
       ))}
 
-      <CardHeader className="p-0 pb-[var(--space-3)]">
-        <div className="flex items-center gap-[var(--space-2)]">
-          <div className="flex h-6 w-6 items-center justify-center rounded bg-[var(--node-logic)] text-[var(--text-primary)]">
-            <Equal size={12} />
-          </div>
-          <span className="font-semibold text-[var(--text-primary)]">
-            {data.identifier.displayName}
+      <NodeHeader
+        icon={<Equal size={14} />}
+        title={data.identifier.displayName}
+        accentClassName={visuals.iconBg}
+        subtitle={categoryLabel}
+        meta={
+          <span className="text-xs font-medium text-[var(--text-secondary)]">
+            {getOperatorLabel()}
           </span>
-        </div>
-      </CardHeader>
+        }
+      />
 
-      <CardContent className="space-y-2 p-0">
-        <div className="rounded border border-[var(--border-primary)] bg-[var(--surface-2)] p-2 text-center">
-          <div className="font-mono text-lg text-[var(--text-primary)]">
+      <div className="space-y-[var(--space-3)]">
+        <div className="rounded border border-[var(--border-primary)] bg-[var(--surface-2)] px-[var(--space-3)] py-[var(--space-2)] text-center">
+          <div className="text-[11px] tracking-[0.18em] text-[var(--text-tertiary)] uppercase">
+            Comparison
+          </div>
+          <div className="mt-[var(--space-2)] text-lg font-semibold text-[var(--text-primary)]">
             A {getOperatorSymbol()} B
           </div>
         </div>
 
-        <div className="flex items-center justify-between">
-          <span className="text-xs text-[var(--text-secondary)]">Operation:</span>
-          <span className="text-xs font-medium text-[var(--text-primary)]">
-            {getOperatorLabel()}
-          </span>
+        <div className="rounded border border-dashed border-[var(--border-primary)] px-[var(--space-3)] py-[var(--space-2)] text-[11px] text-[var(--text-secondary)]">
+          Align both inputs to the same kind of content so the comparison behaves as expected.
         </div>
+      </div>
 
-        <div className="text-center text-xs">
-          <span className="rounded-[var(--radius-sm)] bg-[var(--success-100)] px-[var(--space-2)] py-[var(--space-1)] text-[var(--success-700)]">
-            Boolean Output
-          </span>
-        </div>
-
-        <div className="mt-3 border-t border-[var(--border-primary)] pt-2">
-          <div className="text-center text-xs text-[var(--text-tertiary)]">
-            Type-Safe Comparison
-          </div>
-        </div>
-      </CardContent>
-
-      {/* Output port */}
       {nodeDefinition?.ports.outputs.map((port) => (
-        <Handle
+        <NodePortIndicator
           key={port.id}
-          type="source"
-          position={Position.Right}
           id={port.id}
-          className={`h-3 w-3 ${handleClass} !border-2 !border-[var(--text-primary)]`}
-          style={{ top: '50%' }}
+          side="right"
+          type="source"
+          top="50%"
+          label="Pass / fail signal"
+          description="Sends “yes” when the condition is satisfied."
+          handleClassName={visuals.handle}
+          accent={category}
         />
       ))}
-    </Card>
+    </NodeCard>
   );
 }

--- a/src/components/workspace/nodes/components/node-chrome.tsx
+++ b/src/components/workspace/nodes/components/node-chrome.tsx
@@ -1,0 +1,238 @@
+'use client';
+
+import type {
+  ComponentProps,
+  CSSProperties,
+  MouseEvent as ReactMouseEvent,
+  ReactNode,
+} from 'react';
+import { Handle, Position } from 'reactflow';
+
+import { Card } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+import type { NodeDefinition } from '@/shared/types/definitions';
+
+// Map node categories to shared visual styling so every node renders with the same
+// icon tint, handle color, and port badge treatment.
+type NodeCategory = NodeDefinition['execution']['category'];
+
+const CATEGORY_VISUALS: Record<
+  NodeCategory,
+  {
+    iconBg: string;
+    handle: string;
+    badge: string;
+    label: string;
+  }
+> = {
+  animation: {
+    iconBg: 'bg-[var(--node-animation)]',
+    handle: '!bg-[var(--node-animation)]',
+    badge:
+      'border border-[rgba(139,92,246,0.45)] bg-[rgba(139,92,246,0.16)] text-[var(--text-primary)]',
+    label: 'Animation',
+  },
+  logic: {
+    iconBg: 'bg-[var(--node-logic)]',
+    handle: '!bg-[var(--node-logic)]',
+    badge:
+      'border border-[rgba(59,130,246,0.45)] bg-[rgba(59,130,246,0.16)] text-[var(--text-primary)]',
+    label: 'Logic Control',
+  },
+  geometry: {
+    iconBg: 'bg-[var(--node-geometry)]',
+    handle: '!bg-[var(--node-geometry)]',
+    badge:
+      'border border-[rgba(244,114,182,0.45)] bg-[rgba(244,114,182,0.18)] text-[var(--text-primary)]',
+    label: 'Shape Source',
+  },
+  text: {
+    iconBg: 'bg-[var(--node-text)]',
+    handle: '!bg-[var(--node-text)]',
+    badge:
+      'border border-[rgba(16,185,129,0.45)] bg-[rgba(16,185,129,0.18)] text-[var(--text-primary)]',
+    label: 'Text',
+  },
+  data: {
+    iconBg: 'bg-[var(--node-data)]',
+    handle: '!bg-[var(--node-data)]',
+    badge:
+      'border border-[rgba(34,211,238,0.45)] bg-[rgba(34,211,238,0.16)] text-[var(--text-primary)]',
+    label: 'Data',
+  },
+  timing: {
+    iconBg: 'bg-[var(--node-data)]',
+    handle: '!bg-[var(--node-data)]',
+    badge:
+      'border border-[rgba(34,211,238,0.45)] bg-[rgba(34,211,238,0.16)] text-[var(--text-primary)]',
+    label: 'Timing',
+  },
+  image: {
+    iconBg: 'bg-[var(--node-image)]',
+    handle: '!bg-[var(--node-image)]',
+    badge:
+      'border border-[rgba(234,179,8,0.45)] bg-[rgba(234,179,8,0.18)] text-[var(--text-primary)]',
+    label: 'Media',
+  },
+  input: {
+    iconBg: 'bg-[var(--node-data)]',
+    handle: '!bg-[var(--node-data)]',
+    badge:
+      'border border-[rgba(148,163,184,0.45)] bg-[rgba(148,163,184,0.18)] text-[var(--text-primary)]',
+    label: 'Input',
+  },
+  output: {
+    iconBg: 'bg-[var(--node-output)]',
+    handle: '!bg-[var(--node-output)]',
+    badge:
+      'border border-[rgba(167,139,250,0.45)] bg-[rgba(167,139,250,0.18)] text-[var(--text-primary)]',
+    label: 'Output',
+  },
+};
+
+const DEFAULT_VISUAL = CATEGORY_VISUALS.logic;
+
+export function getNodeCategoryVisuals(category?: NodeCategory) {
+  return CATEGORY_VISUALS[category ?? 'logic'] ?? DEFAULT_VISUAL;
+}
+
+export function getNodeCategoryLabel(category?: NodeCategory) {
+  return (CATEGORY_VISUALS[category ?? 'logic'] ?? DEFAULT_VISUAL).label;
+}
+
+interface NodeCardProps extends ComponentProps<typeof Card> {
+  selected?: boolean;
+  children: ReactNode;
+}
+
+export function NodeCard({ selected, className, children, ...props }: NodeCardProps) {
+  return (
+    <Card
+      selected={selected}
+      className={cn(
+        'relative min-w-[var(--node-min-width)] overflow-hidden px-[var(--space-5)] py-[var(--space-4)]',
+        'flex flex-col gap-[var(--space-3)]',
+        'shadow-[0_12px_28px_rgba(0,0,0,0.45)]',
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </Card>
+  );
+}
+
+interface NodeHeaderProps {
+  icon: ReactNode;
+  title: string;
+  accentClassName: string;
+  subtitle?: string;
+  meta?: ReactNode;
+}
+
+export function NodeHeader({ icon, title, accentClassName, subtitle, meta }: NodeHeaderProps) {
+  return (
+    <div className="flex items-start justify-between gap-[var(--space-2)]">
+      <div className="flex min-w-0 items-start gap-[var(--space-2)]">
+        <div
+          className={cn(
+            'flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-[var(--text-primary)] shadow-[0_0_0_1px_rgba(255,255,255,0.08)]',
+            accentClassName
+          )}
+          aria-hidden="true"
+        >
+          {icon}
+        </div>
+        <div className="min-w-0">
+          <div className="truncate text-sm leading-tight font-semibold text-[var(--text-primary)]">
+            {title}
+          </div>
+          {subtitle ? (
+            <div className="text-[10px] tracking-[0.18em] text-[var(--text-tertiary)] uppercase">
+              {subtitle}
+            </div>
+          ) : null}
+        </div>
+      </div>
+      {meta ? <div className="shrink-0 text-xs text-[var(--text-secondary)]">{meta}</div> : null}
+    </div>
+  );
+}
+
+interface NodePortIndicatorProps {
+  id: string;
+  side: 'left' | 'right';
+  top: string;
+  type: 'source' | 'target';
+  label: string;
+  description?: string;
+  handleClassName: string;
+  badgeClassName?: string;
+  accent?: NodeCategory;
+  icon?: ReactNode;
+  ariaLabel?: string;
+  onHandleDoubleClick?: (event: ReactMouseEvent<HTMLDivElement>) => void;
+}
+
+const HANDLE_BASE_CLASS =
+  'absolute z-[3] h-3 w-3 rounded-full !border-2 !border-[rgba(255,255,255,0.9)] shadow-[0_0_0_3px_rgba(0,0,0,0.4)]';
+
+const BADGE_BASE_CLASS =
+  'inline-flex items-center gap-[var(--space-1)] rounded-full px-[var(--space-2)] py-[var(--space-1)] text-[10px] font-semibold uppercase tracking-[0.08em]';
+
+const LABEL_BASE_CLASS =
+  'pointer-events-none absolute z-[2] flex max-w-[11.5rem] -translate-y-1/2 flex-col gap-[var(--space-1)] leading-tight';
+
+export function NodePortIndicator({
+  id,
+  side,
+  top,
+  type,
+  label,
+  description,
+  handleClassName,
+  badgeClassName,
+  accent,
+  icon,
+  ariaLabel,
+  onHandleDoubleClick,
+}: NodePortIndicatorProps) {
+  const position = side === 'left' ? Position.Left : Position.Right;
+  const labelPosition: CSSProperties =
+    side === 'left'
+      ? { top, left: 'calc(var(--space-4) + 1.35rem)' }
+      : { top, right: 'calc(var(--space-4) + 1.35rem)' };
+  const containerAlignment = side === 'left' ? 'items-start text-left' : 'items-end text-right';
+  const directionGlyph = icon ?? (
+    <span aria-hidden="true" className="text-[0.65rem] leading-none">
+      {side === 'left' ? '⟵' : '⟶'}
+    </span>
+  );
+  const accentVisuals = getNodeCategoryVisuals(accent);
+  const resolvedBadgeClass = badgeClassName ?? accentVisuals.badge;
+
+  return (
+    <>
+      <Handle
+        id={id}
+        type={type}
+        position={position}
+        className={cn(HANDLE_BASE_CLASS, handleClassName)}
+        style={{ top }}
+        aria-label={ariaLabel ?? `${type === 'target' ? 'Input' : 'Output'} • ${label}`}
+        onDoubleClick={onHandleDoubleClick}
+      />
+      <div className={cn(LABEL_BASE_CLASS, containerAlignment)} style={labelPosition}>
+        <span className={cn(BADGE_BASE_CLASS, resolvedBadgeClass)}>
+          {directionGlyph}
+          <span>{label}</span>
+        </span>
+        {description ? (
+          <span className="text-[11px] font-medium text-[var(--text-secondary)]">
+            {description}
+          </span>
+        ) : null}
+      </div>
+    </>
+  );
+}

--- a/src/components/workspace/nodes/duplicate-node.tsx
+++ b/src/components/workspace/nodes/duplicate-node.tsx
@@ -1,68 +1,74 @@
+// src/components/workspace/nodes/duplicate-node.tsx - Duplicate node UI
 'use client';
 
-import { Handle, Position, type NodeProps } from 'reactflow';
-import { Card, CardHeader, CardContent } from '@/components/ui/card';
+import type { NodeProps } from 'reactflow';
+import { Copy } from 'lucide-react';
+
 import { getNodeDefinition } from '@/shared/registry/registry-utils';
 import type { DuplicateNodeData } from '@/shared/types/nodes';
-import { Copy } from 'lucide-react';
+
+import {
+  NodeCard,
+  NodeHeader,
+  NodePortIndicator,
+  getNodeCategoryLabel,
+  getNodeCategoryVisuals,
+} from './components/node-chrome';
 
 export function DuplicateNode({ data, selected }: NodeProps<DuplicateNodeData>) {
   const nodeDefinition = getNodeDefinition('duplicate');
-  const handleClass = 'bg-[var(--node-logic)]';
+  const category = nodeDefinition?.execution.category;
+  const visuals = getNodeCategoryVisuals(category);
+  const categoryLabel = getNodeCategoryLabel(category);
 
   return (
-    <Card selected={selected} className="min-w-[var(--node-min-width)] p-[var(--card-padding)]">
-      {/* Input port */}
+    <NodeCard selected={selected}>
       {nodeDefinition?.ports.inputs.map((port) => (
-        <Handle
+        <NodePortIndicator
           key={port.id}
+          id={port.id}
+          side="left"
           type="target"
-          position={Position.Left}
-          id={port.id}
-          className={`h-3 w-3 ${handleClass} !border-2 !border-[var(--text-primary)]`}
-          style={{ top: `50%` }}
+          top="50%"
+          label="Source stream"
+          description="Connect the objects you want to copy."
+          handleClassName={visuals.handle}
+          accent={category}
         />
       ))}
 
-      <CardHeader className="p-0 pb-[var(--space-3)]">
-        <div className="flex items-center gap-[var(--space-2)]">
-          <div className="flex h-6 w-6 items-center justify-center rounded bg-[var(--node-logic)] text-[var(--text-primary)]">
-            <Copy size={12} />
-          </div>
-          <span className="font-semibold text-[var(--text-primary)]">
-            {data.identifier.displayName}
-          </span>
-        </div>
-      </CardHeader>
+      <NodeHeader
+        icon={<Copy size={14} />}
+        title={data.identifier.displayName}
+        accentClassName={visuals.iconBg}
+        subtitle={categoryLabel}
+        meta={<span className="text-xs text-[var(--text-secondary)]">{data.count} copies</span>}
+      />
 
-      <CardContent className="space-y-2 p-0">
-        <div className="flex items-center justify-between">
-          <span className="text-xs text-[var(--text-secondary)]">Count:</span>
-          <span className="text-xs font-medium text-[var(--text-primary)]">{data.count}</span>
-        </div>
-
-        <div className="text-xs text-[var(--success-500)]">
+      <div className="space-y-[var(--space-2)] text-xs text-[var(--text-secondary)]">
+        <div className="rounded border border-[var(--border-primary)] bg-[var(--surface-2)] px-[var(--space-3)] py-[var(--space-2)]">
           {data.count === 1
-            ? 'Pass-through mode'
-            : `Creating ${data.count - 1} duplicate${data.count > 2 ? 's' : ''}`}
+            ? 'Pass-through mode — no additional duplicates created.'
+            : `Creates ${data.count - 1} extra duplicate${data.count > 2 ? 's' : ''}.`}
         </div>
-
-        <div className="text-xs text-[var(--text-tertiary)] italic">
-          Generic duplication - works with any node type
+        <div className="rounded border border-dashed border-[var(--border-primary)] px-[var(--space-3)] py-[var(--space-2)] text-[11px]">
+          Each duplicate receives a unique ID so downstream nodes can treat them independently.
         </div>
-      </CardContent>
+      </div>
 
-      {/* Output port */}
       {nodeDefinition?.ports.outputs.map((port) => (
-        <Handle
+        <NodePortIndicator
           key={port.id}
-          type="source"
-          position={Position.Right}
           id={port.id}
-          className={`h-3 w-3 ${handleClass} !border-2 !border-[var(--text-primary)]`}
-          style={{ top: `50%` }}
+          side="right"
+          type="source"
+          top="50%"
+          label="Duplicated stream"
+          description="Outputs the original plus any duplicates."
+          handleClassName={visuals.handle}
+          accent={category}
         />
       ))}
-    </Card>
+    </NodeCard>
   );
 }

--- a/src/components/workspace/nodes/filter-node.tsx
+++ b/src/components/workspace/nodes/filter-node.tsx
@@ -1,71 +1,84 @@
-// src/components/workspace/nodes/filter-node.tsx - Confirmed single input/output ports
+// src/components/workspace/nodes/filter-node.tsx - Filter node UI
 'use client';
 
-import { Handle, Position, type NodeProps } from 'reactflow';
-import { Card, CardHeader, CardContent } from '@/components/ui/card';
+import type { NodeProps } from 'reactflow';
+import { Filter as FilterIcon } from 'lucide-react';
+
 import { getNodeDefinition } from '@/shared/registry/registry-utils';
 import type { FilterNodeData } from '@/shared/types/nodes';
-import { Filter } from 'lucide-react';
+
+import {
+  NodeCard,
+  NodeHeader,
+  NodePortIndicator,
+  getNodeCategoryLabel,
+  getNodeCategoryVisuals,
+} from './components/node-chrome';
 
 export function FilterNode({ data, selected }: NodeProps<FilterNodeData>) {
   const nodeDefinition = getNodeDefinition('filter');
+  const category = nodeDefinition?.execution.category;
+  const visuals = getNodeCategoryVisuals(category);
+  const categoryLabel = getNodeCategoryLabel(category);
 
-  const selectedCount = data.selectedObjectIds?.length || 0;
+  const selectedCount = data.selectedObjectIds?.length ?? 0;
   const hasSelection = selectedCount > 0;
 
-  const handleClass = 'bg-[var(--node-logic)]';
-
   return (
-    <Card selected={selected} className="min-w-[var(--node-min-width)] p-[var(--card-padding)]">
-      {/* Single input port */}
+    <NodeCard selected={selected}>
       {nodeDefinition?.ports.inputs.map((port) => (
-        <Handle
+        <NodePortIndicator
           key={port.id}
+          id={port.id}
+          side="left"
           type="target"
-          position={Position.Left}
-          id={port.id}
-          className={`h-3 w-3 ${handleClass} !border-2 !border-[var(--text-primary)]`}
-          style={{ top: `50%` }}
+          top="50%"
+          label="Objects to evaluate"
+          description="Provide the stream you want to narrow down."
+          handleClassName={visuals.handle}
+          accent={category}
         />
       ))}
 
-      <CardHeader className="p-0 pb-[var(--space-3)]">
-        <div className="flex items-center gap-[var(--space-2)]">
-          <div className="flex h-6 w-6 items-center justify-center rounded bg-[var(--node-logic)] text-[var(--text-primary)]">
-            <Filter size={12} />
-          </div>
-          <span className="font-semibold text-[var(--text-primary)]">
-            {data.identifier.displayName}
-          </span>
-        </div>
-      </CardHeader>
+      <NodeHeader
+        icon={<FilterIcon size={14} />}
+        title={data.identifier.displayName}
+        accentClassName={visuals.iconBg}
+        subtitle={categoryLabel}
+        meta={<span className="text-xs text-[var(--text-secondary)]">{selectedCount} kept</span>}
+      />
 
-      <CardContent className="space-y-2 p-0">
+      <div className="space-y-[var(--space-2)] text-xs text-[var(--text-secondary)]">
         <div className="flex items-center justify-between">
-          <span className="text-xs text-[var(--text-secondary)]">Selected:</span>
-          <span className="text-xs font-medium text-[var(--text-primary)]">{selectedCount}</span>
+          <span>Currently passing</span>
+          <span className="font-medium text-[var(--text-primary)]">{selectedCount}</span>
         </div>
+        <div
+          className="rounded border px-[var(--space-3)] py-[var(--space-2)] text-[11px]"
+          style={{
+            borderColor: hasSelection ? 'rgba(16,185,129,0.35)' : 'rgba(245,158,11,0.45)',
+            color: hasSelection ? 'var(--success-500)' : 'var(--warning-600)',
+          }}
+        >
+          {hasSelection
+            ? `${selectedCount} item${selectedCount === 1 ? '' : 's'} allowed to continue.`
+            : 'No items match the current filter.'}
+        </div>
+      </div>
 
-        {hasSelection ? (
-          <div className="text-xs text-[var(--success-500)]">
-            {selectedCount} object{selectedCount !== 1 ? 's' : ''} passing through
-          </div>
-        ) : (
-          <div className="text-xs text-[var(--warning-600)]">No objects selected</div>
-        )}
-      </CardContent>
-
-      {/* Single output port */}
       {nodeDefinition?.ports.outputs.map((port) => (
-        <Handle
+        <NodePortIndicator
           key={port.id}
-          type="source"
-          position={Position.Right}
           id={port.id}
-          className={`h-3 w-3 ${handleClass} !border-2 !border-[var(--text-primary)]`}
-          style={{ top: `50%` }}
+          side="right"
+          type="source"
+          top="50%"
+          label="Filtered stream"
+          description="Emits only the entries that pass the filter."
+          handleClassName={visuals.handle}
+          accent={category}
         />
       ))}
-    </Card>
+    </NodeCard>
   );
 }

--- a/src/components/workspace/nodes/frame-node.tsx
+++ b/src/components/workspace/nodes/frame-node.tsx
@@ -1,14 +1,25 @@
-// src/components/workspace/nodes/frame-node.tsx
+// src/components/workspace/nodes/frame-node.tsx - Frame output node UI
 'use client';
 
-import { Handle, Position, type NodeProps } from 'reactflow';
-import { Card, CardHeader, CardContent } from '@/components/ui/card';
+import type { NodeProps } from 'reactflow';
+import { Image as ImageIcon } from 'lucide-react';
+
 import { getNodeDefinition } from '@/shared/registry/registry-utils';
 import type { FrameNodeData } from '@/shared/types/nodes';
-import { Image as ImageIcon } from 'lucide-react';
+
+import {
+  NodeCard,
+  NodeHeader,
+  NodePortIndicator,
+  getNodeCategoryLabel,
+  getNodeCategoryVisuals,
+} from './components/node-chrome';
 
 export function FrameNode({ data, selected }: NodeProps<FrameNodeData>) {
   const nodeDefinition = getNodeDefinition('frame');
+  const category = nodeDefinition?.execution.category;
+  const visuals = getNodeCategoryVisuals(category);
+  const categoryLabel = getNodeCategoryLabel(category);
 
   const getResolutionLabel = (width: number, height: number) => {
     if (width === 1920 && height === 1080) return 'FHD';
@@ -18,74 +29,57 @@ export function FrameNode({ data, selected }: NodeProps<FrameNodeData>) {
     return 'Custom';
   };
 
-  const handleClass = 'bg-[var(--node-output)]';
+  const resolutionLabel = getResolutionLabel(data.width || 1920, data.height || 1080);
+  const formatLabel = (data.format || 'png').toUpperCase();
 
   return (
-    <Card selected={selected} className="min-w-[var(--node-min-width)] p-[var(--card-padding)]">
+    <NodeCard selected={selected}>
       {nodeDefinition?.ports.inputs.map((port) => (
-        <Handle
+        <NodePortIndicator
           key={port.id}
-          type="target"
-          position={Position.Left}
           id={port.id}
-          className={`h-3 w-3 ${handleClass} !border-2 !border-[var(--text-primary)]`}
-          style={{ top: `50%` }}
+          side="left"
+          type="target"
+          top="50%"
+          label="Image pipeline"
+          description="Connect the flow you want to export as images."
+          handleClassName={visuals.handle}
+          accent={category}
         />
       ))}
 
-      <CardHeader className="p-0 pb-[var(--space-3)]">
-        <div className="flex items-center gap-[var(--space-2)]">
-          <div className="flex h-6 w-6 items-center justify-center rounded bg-[var(--node-output)] text-[var(--text-primary)]">
-            <ImageIcon size={12} />
-          </div>
-          <div className="min-w-0 flex-1">
-            <div className="truncate font-semibold text-[var(--text-primary)]">
-              {data.identifier.displayName}
-            </div>
-          </div>
-        </div>
-      </CardHeader>
+      <NodeHeader
+        icon={<ImageIcon size={14} />}
+        title={data.identifier.displayName}
+        accentClassName={visuals.iconBg}
+        subtitle={categoryLabel}
+        meta={<span className="text-xs text-[var(--text-secondary)]">{formatLabel}</span>}
+      />
 
-      <CardContent className="space-y-[var(--space-2)] p-0 text-xs text-[var(--text-secondary)]">
+      <div className="space-y-[var(--space-2)] text-xs text-[var(--text-secondary)]">
         <div className="flex items-center justify-between">
-          <span>Resolution:</span>
+          <span>Resolution</span>
           <span className="font-medium text-[var(--text-primary)]">
-            {getResolutionLabel(data.width || 1920, data.height || 1080)} ({data.width || 1920}×
-            {data.height || 1080})
+            {resolutionLabel} ({data.width || 1920}×{data.height || 1080})
           </span>
         </div>
-
         <div className="flex items-center justify-between">
-          <span>Background:</span>
-          <div className="flex items-center gap-[var(--space-2)]">
-            <div
-              className="h-4 w-4 rounded border border-[var(--border-primary)]"
-              style={{ backgroundColor: data.backgroundColor || '#000000' }}
-            />
-            <span className="text-xs font-medium text-[var(--text-primary)]">
-              {data.backgroundColor?.toUpperCase() || '#000000'}
-            </span>
-          </div>
-        </div>
-
-        <div className="flex items-center justify-between">
-          <span>Format:</span>
-          <span className="font-medium text-[var(--text-primary)] uppercase">
-            {data.format || 'png'}
+          <span>Background</span>
+          <span className="font-medium text-[var(--text-primary)]">
+            {(data.backgroundColor || '#000000').toUpperCase()}
           </span>
         </div>
-
-        {(data.format || 'png') === 'jpeg' && (
+        {formatLabel === 'JPEG' ? (
           <div className="flex items-center justify-between">
-            <span>Quality:</span>
-            <span className="font-medium text-[var(--text-primary)]">{data.quality || 90}</span>
+            <span>Quality</span>
+            <span className="font-medium text-[var(--text-primary)]">{data.quality ?? 90}</span>
           </div>
-        )}
-
-        <div className="mt-[var(--space-4)] border-t border-[var(--border-primary)] pt-[var(--space-3)] text-center text-xs text-[var(--text-tertiary)]">
-          Final Image Output
+        ) : null}
+        <div className="rounded border border-dashed border-[var(--border-primary)] px-[var(--space-3)] py-[var(--space-2)] text-[11px]">
+          Ideal for exporting still frames—connect downstream automation or download from the render
+          panel.
         </div>
-      </CardContent>
-    </Card>
+      </div>
+    </NodeCard>
   );
 }

--- a/src/components/workspace/nodes/if-else-node.tsx
+++ b/src/components/workspace/nodes/if-else-node.tsx
@@ -1,86 +1,85 @@
-// src/components/workspace/nodes/if-else-node.tsx - If/Else logic node
+// src/components/workspace/nodes/if-else-node.tsx - If/Else node UI
 'use client';
 
-import { Handle, Position, type NodeProps } from 'reactflow';
-import { Card, CardHeader, CardContent } from '@/components/ui/card';
-
-import type { IfElseNodeData } from '@/shared/types/nodes';
+import type { NodeProps } from 'reactflow';
 import { GitBranch } from 'lucide-react';
 
+import type { IfElseNodeData } from '@/shared/types/nodes';
+import { getNodeDefinition } from '@/shared/registry/registry-utils';
+
+import {
+  NodeCard,
+  NodeHeader,
+  NodePortIndicator,
+  getNodeCategoryLabel,
+  getNodeCategoryVisuals,
+} from './components/node-chrome';
+
 export function IfElseNode({ data, selected }: NodeProps<IfElseNodeData>) {
-  const handleClass = 'bg-[var(--node-logic)]';
+  const nodeDefinition = getNodeDefinition('if_else');
+  const category = nodeDefinition?.execution.category;
+  const visuals = getNodeCategoryVisuals(category);
+  const categoryLabel = getNodeCategoryLabel(category);
 
   return (
-    <Card selected={selected} className="min-w-[var(--node-min-width)] p-[var(--card-padding)]">
-      {/* Condition input port */}
-      <Handle
-        type="target"
-        position={Position.Left}
+    <NodeCard selected={selected}>
+      <NodePortIndicator
         id="condition"
-        className={`h-3 w-3 ${handleClass} !border-2 !border-[var(--text-primary)]`}
-        style={{ top: '35%' }}
-      />
-
-      {/* Data input port */}
-      <Handle
+        side="left"
         type="target"
-        position={Position.Left}
+        top="35%"
+        label="Condition signal"
+        description="When this is active the True branch is used."
+        handleClassName={visuals.handle}
+        accent={category}
+      />
+      <NodePortIndicator
         id="data"
-        className={`h-3 w-3 ${handleClass} !border-2 !border-[var(--text-primary)]`}
-        style={{ top: '65%' }}
+        side="left"
+        type="target"
+        top="65%"
+        label="Data to route"
+        description="This payload is sent to either branch."
+        handleClassName={visuals.handle}
+        accent={category}
       />
 
-      <CardHeader className="p-0 pb-[var(--space-3)]">
-        <div className="flex items-center gap-[var(--space-2)]">
-          <div className="flex h-6 w-6 items-center justify-center rounded bg-[var(--node-logic)] text-[var(--text-primary)]">
-            <GitBranch size={12} />
-          </div>
-          <span className="font-semibold text-[var(--text-primary)]">
-            {data.identifier.displayName}
-          </span>
-        </div>
-      </CardHeader>
+      <NodeHeader
+        icon={<GitBranch size={14} />}
+        title={data.identifier.displayName}
+        accentClassName={visuals.iconBg}
+        subtitle={categoryLabel}
+      />
 
-      <CardContent className="space-y-2 p-0">
-        <div className="rounded border border-[var(--border-primary)] bg-[var(--surface-2)] p-2 text-center">
-          <div className="text-sm text-[var(--text-primary)]">
-            if condition → route data to true / else → false
-          </div>
+      <div className="space-y-[var(--space-2)] text-xs text-[var(--text-secondary)]">
+        <div className="rounded border border-dashed border-[var(--border-primary)] px-[var(--space-3)] py-[var(--space-2)] text-[11px]">
+          Use this node to branch a flow—connect any yes/no signal to control which output is
+          active.
         </div>
+      </div>
 
-        <div className="grid grid-cols-2 gap-1 text-xs">
-          <div className="text-center text-[var(--success-500)]">True</div>
-          <div className="text-center text-[var(--danger-500)]">False</div>
-        </div>
-
-        <div className="text-center text-xs">
-          <span className="rounded-[var(--radius-sm)] bg-[var(--accent-100)] px-[var(--space-2)] py-[var(--space-1)] text-[var(--accent-900)]">
-            Data Router
-          </span>
-        </div>
-
-        <div className="mt-3 border-t border-[var(--border-primary)] pt-2">
-          <div className="text-center text-xs text-[var(--text-tertiary)]">
-            Condition + Data → Routed Data
-          </div>
-        </div>
-      </CardContent>
-
-      {/* Output ports */}
-      <Handle
-        type="source"
-        position={Position.Right}
+      <NodePortIndicator
         id="true_path"
-        className={`h-3 w-3 !border-2 !border-[var(--text-primary)] bg-[var(--success-500)]`}
-        style={{ top: '35%' }}
-      />
-      <Handle
+        side="right"
         type="source"
-        position={Position.Right}
-        id="false_path"
-        className={`h-3 w-3 !border-2 !border-[var(--text-primary)] bg-[var(--danger-500)]`}
-        style={{ top: '65%' }}
+        top="35%"
+        label="True path"
+        description="Emits when the condition is active."
+        handleClassName="!bg-[var(--success-500)]"
+        badgeClassName="border border-[rgba(16,185,129,0.45)] bg-[rgba(16,185,129,0.16)] text-[var(--text-primary)]"
+        icon={<span className="text-[0.65rem] leading-none">✓</span>}
       />
-    </Card>
+      <NodePortIndicator
+        id="false_path"
+        side="right"
+        type="source"
+        top="65%"
+        label="False path"
+        description="Emits when the condition is inactive."
+        handleClassName="!bg-[var(--danger-500)]"
+        badgeClassName="border border-[rgba(239,68,68,0.45)] bg-[rgba(239,68,68,0.18)] text-[var(--text-primary)]"
+        icon={<span className="text-[0.65rem] leading-none">✕</span>}
+      />
+    </NodeCard>
   );
 }

--- a/src/components/workspace/nodes/image-node.tsx
+++ b/src/components/workspace/nodes/image-node.tsx
@@ -1,41 +1,55 @@
+// src/components/workspace/nodes/image-node.tsx - Image input node UI
 'use client';
 
-import { Handle, Position, type NodeProps } from 'reactflow';
-import { Card, CardHeader, CardContent } from '@/components/ui/card';
+import type { NodeProps } from 'reactflow';
+import { Image as ImageIcon } from 'lucide-react';
+
 import { getNodeDefinition } from '@/shared/registry/registry-utils';
 import type { ImageNodeData } from '@/shared/types/nodes';
-import { Image } from 'lucide-react';
+
+import {
+  NodeCard,
+  NodeHeader,
+  NodePortIndicator,
+  getNodeCategoryLabel,
+  getNodeCategoryVisuals,
+} from './components/node-chrome';
 
 export function ImageNode({ data, selected }: NodeProps<ImageNodeData>) {
   const nodeDefinition = getNodeDefinition('image');
+  const category = nodeDefinition?.execution.category;
+  const visuals = getNodeCategoryVisuals(category);
+  const categoryLabel = getNodeCategoryLabel(category);
 
   return (
-    <Card selected={selected} className="min-w-[var(--node-min-width)] p-[var(--card-padding)]">
-      <CardHeader className="p-0 pb-[var(--space-3)]">
-        <div className="flex items-center gap-[var(--space-2)]">
-          <div className="flex h-6 w-6 items-center justify-center rounded bg-[var(--node-input)] text-[var(--text-primary)]">
-            <Image size={12} aria-label="Image node icon" />
-          </div>
-          <span className="font-semibold text-[var(--text-primary)]">
-            {data.identifier.displayName}
-          </span>
-        </div>
-      </CardHeader>
+    <NodeCard selected={selected}>
+      <NodeHeader
+        icon={<ImageIcon size={14} />}
+        title={data.identifier.displayName}
+        accentClassName={visuals.iconBg}
+        subtitle={categoryLabel}
+        meta={<span className="text-xs text-[var(--text-secondary)]">Library source</span>}
+      />
 
-      <CardContent className="space-y-1 p-0 text-xs text-[var(--text-secondary)]">
-        <div className="text-[var(--text-tertiary)]">Connect to Media node for editing</div>
-      </CardContent>
+      <div className="space-y-[var(--space-2)] text-xs text-[var(--text-secondary)]">
+        <div className="rounded border border-dashed border-[var(--border-primary)] px-[var(--space-3)] py-[var(--space-2)] text-[11px]">
+          Drop this node to bring images from your asset library into the graph.
+        </div>
+      </div>
 
       {nodeDefinition?.ports.outputs.map((port) => (
-        <Handle
+        <NodePortIndicator
           key={port.id}
-          type="source"
-          position={Position.Right}
           id={port.id}
-          className="h-3 w-3 !border-2 !border-[var(--text-primary)] bg-[var(--node-input)]"
-          style={{ top: '50%' }}
+          side="right"
+          type="source"
+          top="50%"
+          label="Image stream"
+          description="Emits the selected image for further processing."
+          handleClassName={visuals.handle}
+          accent={category}
         />
       ))}
-    </Card>
+    </NodeCard>
   );
 }

--- a/src/components/workspace/nodes/insert-node.tsx
+++ b/src/components/workspace/nodes/insert-node.tsx
@@ -1,69 +1,81 @@
-// src/components/workspace/nodes/insert-node.tsx - Simplified single input/output ports
+// src/components/workspace/nodes/insert-node.tsx - Timing insert node UI
 'use client';
 
-import { Handle, Position, type NodeProps } from 'reactflow';
-import { Card, CardHeader, CardContent } from '@/components/ui/card';
+import React from 'react';
+import type { NodeProps } from 'reactflow';
+import { Clock3 } from 'lucide-react';
+
 import { getNodeDefinition } from '@/shared/registry/registry-utils';
 import type { InsertNodeData } from '@/shared/types/nodes';
-import React from 'react';
+
+import {
+  NodeCard,
+  NodeHeader,
+  NodePortIndicator,
+  getNodeCategoryLabel,
+  getNodeCategoryVisuals,
+} from './components/node-chrome';
 import { InsertModal } from './InsertModal';
 
 export function InsertNode({ data, selected }: NodeProps<InsertNodeData>) {
   const nodeDefinition = getNodeDefinition('insert');
   const [open, setOpen] = React.useState(false);
-
-  const handleClass = 'bg-[var(--node-data)]';
+  const category = nodeDefinition?.execution.category;
+  const visuals = getNodeCategoryVisuals(category);
+  const categoryLabel = getNodeCategoryLabel(category);
+  const appearanceTime = data.appearanceTime ?? 0;
 
   return (
-    <Card
-      selected={selected}
-      className="min-w-[var(--node-min-width)] cursor-pointer p-[var(--card-padding)]"
-      onDoubleClick={() => setOpen(true)}
-    >
-      {/* Single input port */}
+    <NodeCard selected={selected} className="cursor-pointer" onDoubleClick={() => setOpen(true)}>
       {nodeDefinition?.ports.inputs.map((port) => (
-        <Handle
+        <NodePortIndicator
           key={port.id}
+          id={port.id}
+          side="left"
           type="target"
-          position={Position.Left}
-          id={port.id}
-          className={`h-3 w-3 ${handleClass} !border-2 !border-[var(--text-primary)]`}
-          style={{ top: `50%` }}
+          top="50%"
+          label="Objects to schedule"
+          description="Connect the stream you want to delay."
+          handleClassName={visuals.handle}
+          accent={category}
         />
       ))}
 
-      <CardHeader className="p-0 pb-[var(--space-3)]">
-        <div className="flex items-center gap-[var(--space-2)]">
-          <div className="flex h-6 w-6 items-center justify-center rounded bg-[var(--node-data)] text-sm font-bold text-[var(--text-primary)]">
-            ⏰
-          </div>
-          <span className="font-semibold text-[var(--text-primary)]">
-            {data.identifier.displayName}
-          </span>
-        </div>
-      </CardHeader>
+      <NodeHeader
+        icon={<Clock3 size={14} />}
+        title={data.identifier.displayName}
+        accentClassName={visuals.iconBg}
+        subtitle={categoryLabel}
+        meta={<span className="text-xs text-[var(--text-secondary)]">{appearanceTime}s</span>}
+      />
 
-      <CardContent className="space-y-1 p-0 text-xs text-[var(--text-secondary)]">
-        <div>Appears at: {data.appearanceTime}s</div>
-        <div className="pt-1 text-[10px] text-[var(--text-tertiary)]">
-          Double-click to edit per-object times
+      <div className="space-y-[var(--space-2)] text-xs text-[var(--text-secondary)]">
+        <div className="flex items-center justify-between">
+          <span>Start time</span>
+          <span className="font-medium text-[var(--text-primary)]">{appearanceTime}s</span>
         </div>
-      </CardContent>
+        <div className="rounded border border-dashed border-[var(--border-primary)] px-[var(--space-3)] py-[var(--space-2)] text-[11px]">
+          Double-click to configure per-object offsets or bind this start time to another node.
+        </div>
+      </div>
 
-      {/* Single output port */}
       {nodeDefinition?.ports.outputs.map((port) => (
-        <Handle
+        <NodePortIndicator
           key={port.id}
-          type="source"
-          position={Position.Right}
           id={port.id}
-          className={`h-3 w-3 ${handleClass} !border-2 !border-[var(--text-primary)]`}
-          style={{ top: `50%` }}
+          side="right"
+          type="source"
+          top="50%"
+          label="Scheduled objects"
+          description="Emits the stream once the start time is reached."
+          handleClassName={visuals.handle}
+          accent={category}
         />
       ))}
+
       {open ? (
         <InsertModal isOpen={open} onClose={() => setOpen(false)} nodeId={data.identifier.id} />
       ) : null}
-    </Card>
+    </NodeCard>
   );
 }

--- a/src/components/workspace/nodes/math-op-node.tsx
+++ b/src/components/workspace/nodes/math-op-node.tsx
@@ -1,40 +1,51 @@
-// src/components/workspace/nodes/math-op-node.tsx - Math operation logic node
+// src/components/workspace/nodes/math-op-node.tsx - Math operation node UI
 'use client';
 
-import { Handle, Position, type NodeProps } from 'reactflow';
-import { Card, CardHeader, CardContent } from '@/components/ui/card';
+import type { NodeProps } from 'reactflow';
+import { Calculator } from 'lucide-react';
+
 import { getNodeDefinitionWithDynamicPorts } from '@/shared/registry/registry-utils';
 import type { MathOpNodeData } from '@/shared/types/nodes';
-import { Calculator } from 'lucide-react';
+
+import {
+  NodeCard,
+  NodeHeader,
+  NodePortIndicator,
+  getNodeCategoryLabel,
+  getNodeCategoryVisuals,
+} from './components/node-chrome';
 
 export function MathOpNode({ data, selected }: NodeProps<MathOpNodeData>) {
   const nodeDefinition = getNodeDefinitionWithDynamicPorts(
     'math_op',
     data as unknown as Record<string, unknown>
   );
+  const category = nodeDefinition?.execution.category;
+  const visuals = getNodeCategoryVisuals(category);
+  const categoryLabel = getNodeCategoryLabel(category);
 
   const getOperatorDisplay = () => {
     switch (data.operator) {
       case 'add':
-        return 'ADD';
+        return 'Add';
       case 'subtract':
-        return 'SUB';
+        return 'Subtract';
       case 'multiply':
-        return 'MUL';
+        return 'Multiply';
       case 'divide':
-        return 'DIV';
+        return 'Divide';
       case 'modulo':
-        return 'MOD';
+        return 'Modulo';
       case 'power':
-        return 'POW';
+        return 'Power';
       case 'sqrt':
-        return 'SQRT';
+        return 'Square root';
       case 'abs':
-        return 'ABS';
+        return 'Absolute';
       case 'min':
-        return 'MIN';
+        return 'Minimum';
       case 'max':
-        return 'MAX';
+        return 'Maximum';
     }
   };
 
@@ -43,7 +54,7 @@ export function MathOpNode({ data, selected }: NodeProps<MathOpNodeData>) {
       case 'add':
         return '+';
       case 'subtract':
-        return '-';
+        return '−';
       case 'multiply':
         return '×';
       case 'divide':
@@ -53,9 +64,9 @@ export function MathOpNode({ data, selected }: NodeProps<MathOpNodeData>) {
       case 'power':
         return '^';
       case 'sqrt':
-        return '√A';
+        return '√';
       case 'abs':
-        return '|A|';
+        return '| |';
       case 'min':
         return 'min';
       case 'max':
@@ -63,76 +74,63 @@ export function MathOpNode({ data, selected }: NodeProps<MathOpNodeData>) {
     }
   };
 
-  const isUnaryOperation = () => data.operator === 'sqrt' || data.operator === 'abs';
-
-  const handleClass = 'bg-[var(--node-logic)]';
+  const isUnaryOperation = data.operator === 'sqrt' || data.operator === 'abs';
 
   return (
-    <Card selected={selected} className="min-w-[var(--node-min-width)] p-[var(--card-padding)]">
-      {/* Dynamic input ports */}
+    <NodeCard selected={selected}>
       {nodeDefinition?.ports.inputs.map((port, index) => (
-        <Handle
+        <NodePortIndicator
           key={port.id}
+          id={port.id}
+          side="left"
           type="target"
-          position={Position.Left}
-          id={port.id}
-          className={`h-3 w-3 ${handleClass} !border-2 !border-[var(--text-primary)]`}
-          style={{ top: `${35 + index * 30}%` }}
+          top={`${35 + index * 30}%`}
+          label={index === 0 ? 'First value' : 'Second value'}
+          description={
+            index === 0
+              ? 'Primary value for the calculation.'
+              : 'Optional second value when the rule needs it.'
+          }
+          handleClassName={visuals.handle}
+          accent={category}
+          icon={
+            <span className="text-[0.65rem] leading-none font-semibold">
+              {index === 0 ? 'A' : 'B'}
+            </span>
+          }
         />
       ))}
 
-      <CardHeader className="p-0 pb-[var(--space-3)]">
-        <div className="flex items-center gap-[var(--space-2)]">
-          <div className="flex h-6 w-6 items-center justify-center rounded bg-[var(--node-logic)] text-[var(--text-primary)]">
-            <Calculator size={12} />
-          </div>
-          <span className="font-semibold text-[var(--text-primary)]">
-            {data.identifier.displayName}
-          </span>
-        </div>
-      </CardHeader>
+      <NodeHeader
+        icon={<Calculator size={14} />}
+        title={data.identifier.displayName}
+        accentClassName={visuals.iconBg}
+        subtitle={categoryLabel}
+        meta={<span className="text-xs text-[var(--text-secondary)]">{getOperatorDisplay()}</span>}
+      />
 
-      <CardContent className="space-y-2 p-0">
-        <div className="rounded border border-[var(--border-primary)] bg-[var(--surface-2)] p-2 text-center">
-          <div className="font-mono text-sm text-[var(--text-primary)]">
-            Math ({getOperatorDisplay()})
-          </div>
-          <div className="mt-1 font-mono text-lg text-[var(--text-primary)]">
-            {isUnaryOperation() ? getOperatorSymbol() : `A ${getOperatorSymbol()} B`}
-          </div>
+      <div className="space-y-[var(--space-2)] text-xs text-[var(--text-secondary)]">
+        <div className="rounded border border-[var(--border-primary)] bg-[var(--surface-2)] px-[var(--space-3)] py-[var(--space-2)] text-center text-[var(--text-primary)]">
+          {isUnaryOperation ? `${getOperatorSymbol()} A` : `A ${getOperatorSymbol()} B`}
         </div>
-
-        <div className="flex items-center justify-between">
-          <span className="text-xs text-[var(--text-secondary)]">Operation:</span>
-          <span className="text-xs font-medium text-[var(--text-primary)]">
-            {getOperatorDisplay()}
-          </span>
+        <div className="rounded border border-dashed border-[var(--border-primary)] px-[var(--space-3)] py-[var(--space-2)] text-[11px]">
+          Chain math operations together to build expressions without leaving the canvas.
         </div>
+      </div>
 
-        <div className="text-center text-xs">
-          <span className="rounded-[var(--radius-sm)] bg-[var(--accent-100)] px-[var(--space-2)] py-[var(--space-1)] text-[var(--accent-900)]">
-            Number Math
-          </span>
-        </div>
-
-        <div className="mt-3 border-t border-[var(--border-primary)] pt-2">
-          <div className="text-center text-xs text-[var(--text-tertiary)]">
-            {isUnaryOperation() ? '1 Input' : '2 Inputs'} → Number
-          </div>
-        </div>
-      </CardContent>
-
-      {/* Output port */}
       {nodeDefinition?.ports.outputs.map((port) => (
-        <Handle
+        <NodePortIndicator
           key={port.id}
-          type="source"
-          position={Position.Right}
           id={port.id}
-          className={`h-3 w-3 ${handleClass} !border-2 !border-[var(--text-primary)]`}
-          style={{ top: '50%' }}
+          side="right"
+          type="source"
+          top="50%"
+          label="Calculated result"
+          description="Emits the outcome of this operation."
+          handleClassName={visuals.handle}
+          accent={category}
         />
       ))}
-    </Card>
+    </NodeCard>
   );
 }

--- a/src/components/workspace/nodes/media-node.tsx
+++ b/src/components/workspace/nodes/media-node.tsx
@@ -1,86 +1,103 @@
+// src/components/workspace/nodes/media-node.tsx - Media processing node UI
 'use client';
 
-import { Handle, Position, type NodeProps } from 'reactflow';
-import { Card, CardHeader, CardContent } from '@/components/ui/card';
+import type { NodeProps } from 'reactflow';
+import { Image, SlidersHorizontal } from 'lucide-react';
+
 import { getNodeDefinition } from '@/shared/registry/registry-utils';
 import type { MediaNodeData } from '@/shared/types/nodes';
-import { Image, Settings } from 'lucide-react';
 
-export function MediaNode({
-  data,
-  selected,
-  onOpenMedia,
-}: NodeProps<MediaNodeData> & { onOpenMedia?: () => void }) {
+import {
+  NodeCard,
+  NodeHeader,
+  NodePortIndicator,
+  getNodeCategoryLabel,
+  getNodeCategoryVisuals,
+} from './components/node-chrome';
+
+interface MediaNodeProps extends NodeProps<MediaNodeData> {
+  onOpenMedia?: () => void;
+}
+
+export function MediaNode({ data, selected, onOpenMedia }: MediaNodeProps) {
   const nodeDefinition = getNodeDefinition('media');
+  const category = nodeDefinition?.execution.category;
+  const visuals = getNodeCategoryVisuals(category);
+  const categoryLabel = getNodeCategoryLabel(category);
 
   const handleDoubleClick = () => {
     if (onOpenMedia) {
       onOpenMedia();
-    } else {
-      // Dispatch custom event to open media editor
-      window.dispatchEvent(
-        new CustomEvent('open-media-editor', {
-          detail: { nodeId: data.identifier.id },
-        })
-      );
+      return;
     }
+    window.dispatchEvent(
+      new CustomEvent('open-media-editor', {
+        detail: { nodeId: data.identifier.id },
+      })
+    );
   };
 
-  const currentAsset = data.imageAssetId ? 'Selected' : 'No asset';
-  const cropInfo = data.cropWidth > 0 ? `${data.cropWidth}×${data.cropHeight}` : 'Full size';
+  const currentAsset = data.imageAssetId ? 'Selected asset' : 'No asset yet';
+  const cropInfo = data.cropWidth > 0 ? `${data.cropWidth}×${data.cropHeight}` : 'Full image';
+  const displayInfo =
+    data.displayWidth > 0 ? `${data.displayWidth}×${data.displayHeight}` : 'Auto fit';
 
   return (
-    <Card
-      selected={selected}
-      className="min-w-[var(--node-min-width)] cursor-pointer p-[var(--card-padding)] transition-all hover:bg-[var(--surface-interactive)]"
-      onDoubleClick={handleDoubleClick}
-    >
-      <CardHeader className="p-0 pb-[var(--space-3)]">
-        <div className="flex items-center gap-[var(--space-2)]">
-          <div className="flex h-6 w-6 items-center justify-center rounded bg-[var(--node-animation)] text-[var(--text-primary)]">
-            <Image size={12} aria-label="Media node icon" />
-          </div>
-          <div className="min-w-0 flex-1">
-            <div className="truncate font-semibold text-[var(--text-primary)]">
-              {data.identifier.displayName}
-            </div>
-          </div>
-          <Settings size={12} className="text-[var(--text-tertiary)]" />
-        </div>
-      </CardHeader>
-
-      <CardContent className="space-y-1 p-0 text-xs text-[var(--text-secondary)]">
-        <div className="truncate">Asset: {currentAsset}</div>
-        <div>Crop: {cropInfo}</div>
-        <div>
-          Display: {data.displayWidth > 0 ? `${data.displayWidth}×${data.displayHeight}` : 'Auto'}
-        </div>
-        <div className="pt-1 text-[10px] text-[var(--text-tertiary)]">
-          Double-click to edit in Media tab
-        </div>
-      </CardContent>
-
+    <NodeCard selected={selected} className="cursor-pointer" onDoubleClick={handleDoubleClick}>
       {nodeDefinition?.ports.inputs.map((port) => (
-        <Handle
+        <NodePortIndicator
           key={port.id}
-          type="target"
-          position={Position.Left}
           id={port.id}
-          className="h-3 w-3 !border-2 !border-[var(--text-primary)] bg-[var(--node-animation)]"
-          style={{ top: '50%' }}
+          side="left"
+          type="target"
+          top="50%"
+          label="Image stream"
+          description="Provide the image you want to edit."
+          handleClassName={visuals.handle}
+          accent={category}
         />
       ))}
+
+      <NodeHeader
+        icon={<Image size={14} />}
+        title={data.identifier.displayName}
+        accentClassName={visuals.iconBg}
+        subtitle={categoryLabel}
+        meta={
+          <span className="flex items-center gap-[var(--space-1)] text-xs text-[var(--text-secondary)]">
+            <SlidersHorizontal size={12} />
+            {cropInfo}
+          </span>
+        }
+      />
+
+      <div className="space-y-[var(--space-2)] text-xs text-[var(--text-secondary)]">
+        <div className="flex items-center justify-between">
+          <span>Asset</span>
+          <span className="font-medium text-[var(--text-primary)]">{currentAsset}</span>
+        </div>
+        <div className="flex items-center justify-between">
+          <span>Display</span>
+          <span className="font-medium text-[var(--text-primary)]">{displayInfo}</span>
+        </div>
+        <div className="rounded border border-dashed border-[var(--border-primary)] px-[var(--space-3)] py-[var(--space-2)] text-[11px]">
+          Double-click to adjust cropping, scaling, and alignment in the media panel.
+        </div>
+      </div>
 
       {nodeDefinition?.ports.outputs.map((port) => (
-        <Handle
+        <NodePortIndicator
           key={port.id}
-          type="source"
-          position={Position.Right}
           id={port.id}
-          className="h-3 w-3 !border-2 !border-[var(--text-primary)] bg-[var(--node-animation)]"
-          style={{ top: '50%' }}
+          side="right"
+          type="source"
+          top="50%"
+          label="Processed image"
+          description="Outputs the image with the configured adjustments."
+          handleClassName={visuals.handle}
+          accent={category}
         />
       ))}
-    </Card>
+    </NodeCard>
   );
 }

--- a/src/components/workspace/nodes/merge-node.tsx
+++ b/src/components/workspace/nodes/merge-node.tsx
@@ -1,93 +1,99 @@
+// src/components/workspace/nodes/merge-node.tsx - Merge node UI
 'use client';
 
-import { Handle, Position, type NodeProps } from 'reactflow';
-import { Card, CardHeader, CardContent } from '@/components/ui/card';
+import type { NodeProps } from 'reactflow';
+import { GitMerge } from 'lucide-react';
 
 import type { MergeNodeData } from '@/shared/types/nodes';
+import { getNodeDefinitionWithDynamicPorts } from '@/shared/registry/registry-utils';
+
+import {
+  NodeCard,
+  NodeHeader,
+  NodePortIndicator,
+  getNodeCategoryLabel,
+  getNodeCategoryVisuals,
+} from './components/node-chrome';
 
 export function MergeNode({ data, selected }: NodeProps<MergeNodeData>) {
-  const portCount = data.inputPortCount || 2;
+  const nodeDefinition = getNodeDefinitionWithDynamicPorts(
+    'merge',
+    data as unknown as Record<string, unknown>
+  );
+  const category = nodeDefinition?.execution.category;
+  const visuals = getNodeCategoryVisuals(category);
+  const categoryLabel = getNodeCategoryLabel(category);
+  const portCount = data.inputPortCount || nodeDefinition?.ports.inputs.length || 2;
 
-  // Generate dynamic input ports
-  const inputPorts = Array.from({ length: portCount }, (_, i) => ({
-    id: `input${i + 1}`,
-    label: i === 0 ? 'Input 1 (Priority)' : `Input ${i + 1}`,
-  }));
-
-  // Calculate port spacing to avoid overlap
   const getPortTopPosition = (index: number) => {
     if (portCount <= 2) {
       return index === 0 ? '30%' : '70%';
-    } else if (portCount === 3) {
-      return ['25%', '50%', '75%'][index];
-    } else if (portCount === 4) {
-      return ['20%', '40%', '60%', '80%'][index];
-    } else {
-      // 5 ports
-      return ['15%', '30%', '50%', '70%', '85%'][index];
     }
+    if (portCount === 3) {
+      return ['25%', '50%', '75%'][index];
+    }
+    if (portCount === 4) {
+      return ['20%', '40%', '60%', '80%'][index];
+    }
+    return ['15%', '30%', '50%', '70%', '85%'][index];
   };
 
-  // Dynamic height based on port count for better port spacing
   const getNodeHeight = () => {
-    if (portCount <= 2) return 'min-h-[120px]';
-    if (portCount === 3) return 'min-h-[140px]';
-    if (portCount === 4) return 'min-h-[160px]';
-    return 'min-h-[180px]'; // 5 ports
+    if (portCount <= 2) return 'min-h-[130px]';
+    if (portCount === 3) return 'min-h-[150px]';
+    if (portCount === 4) return 'min-h-[170px]';
+    return 'min-h-[190px]';
   };
-
-  const handleClass = 'bg-[var(--node-logic)]';
 
   return (
-    <Card
-      className={`min-w-[var(--node-min-width)] p-[var(--card-padding)] ${getNodeHeight()} ${selected ? 'ring-2 ring-[var(--accent-primary)]' : ''}`}
-    >
-      {/* Dynamic input ports */}
-      {inputPorts.map((port, index) => (
-        <Handle
+    <NodeCard selected={selected} className={getNodeHeight()}>
+      {nodeDefinition?.ports.inputs.map((port, index) => (
+        <NodePortIndicator
           key={port.id}
-          type="target"
-          position={Position.Left}
           id={port.id}
-          className={`h-3 w-3 ${handleClass} !border-2 !border-[var(--text-primary)]`}
-          style={{ top: getPortTopPosition(index) }}
+          side="left"
+          type="target"
+          top={getPortTopPosition(index) ?? '50%'}
+          label={index === 0 ? 'Primary stream' : `Stream ${index + 1}`}
+          description={
+            index === 0 ? 'Takes priority when IDs collide.' : 'Blends in when space is available.'
+          }
+          handleClassName={visuals.handle}
+          accent={category}
         />
       ))}
 
-      <CardHeader className="p-0 pb-[var(--space-3)]">
-        <div className="flex items-center gap-[var(--space-2)]">
-          <div className="flex h-6 w-6 items-center justify-center rounded bg-[var(--node-logic)] text-sm font-bold text-[var(--text-primary)]">
-            ⊕
-          </div>
-          <span className="font-semibold text-[var(--text-primary)]">
-            {data.identifier.displayName}
-          </span>
-        </div>
-      </CardHeader>
-
-      <CardContent className="space-y-2 p-0">
-        <div className="flex items-center justify-between">
-          <span className="text-xs text-[var(--text-secondary)]">Ports:</span>
-          <span className="text-xs font-medium text-[var(--text-primary)]">{portCount}</span>
-        </div>
-
-        <div className="text-xs text-[var(--accent-primary)]">Port 1 has merge priority</div>
-
-        <div className="mt-3 border-t border-[var(--border-primary)] pt-2">
-          <div className="text-center text-xs text-[var(--text-tertiary)]">
-            Resolves object ID conflicts
-          </div>
-        </div>
-      </CardContent>
-
-      {/* Single output port */}
-      <Handle
-        type="source"
-        position={Position.Right}
-        id="output"
-        className={`h-3 w-3 ${handleClass} !border-2 !border-[var(--text-primary)]`}
-        style={{ top: '50%' }}
+      <NodeHeader
+        icon={<GitMerge size={14} />}
+        title={data.identifier.displayName}
+        accentClassName={visuals.iconBg}
+        subtitle={categoryLabel}
+        meta={<span className="text-xs text-[var(--text-secondary)]">{portCount} inputs</span>}
       />
-    </Card>
+
+      <div className="space-y-[var(--space-2)] text-xs text-[var(--text-secondary)]">
+        <div className="rounded border border-[var(--border-primary)] bg-[var(--surface-2)] px-[var(--space-3)] py-[var(--space-2)]">
+          Incoming streams are merged in order—use the first input when you need deterministic
+          overrides.
+        </div>
+        <div className="rounded border border-dashed border-[var(--border-primary)] px-[var(--space-3)] py-[var(--space-2)] text-[11px]">
+          Helpful for bringing parallel branches back together after conditional logic.
+        </div>
+      </div>
+
+      {nodeDefinition?.ports.outputs.map((port) => (
+        <NodePortIndicator
+          key={port.id}
+          id={port.id}
+          side="right"
+          type="source"
+          top="50%"
+          label="Merged stream"
+          description="Outputs a single flow containing all upstream entries."
+          handleClassName={visuals.handle}
+          accent={category}
+        />
+      ))}
+    </NodeCard>
   );
 }

--- a/src/components/workspace/nodes/rectangle-node.tsx
+++ b/src/components/workspace/nodes/rectangle-node.tsx
@@ -1,47 +1,66 @@
-// src/components/workspace/nodes/rectangle-node.tsx - Simplified single output port
+// src/components/workspace/nodes/rectangle-node.tsx - Rectangular geometry node UI
 'use client';
 
-import { Handle, Position, type NodeProps } from 'reactflow';
-import { Card, CardHeader, CardContent } from '@/components/ui/card';
+import type { NodeProps } from 'reactflow';
+import { Square as SquareIcon } from 'lucide-react';
+
 import { getNodeDefinition } from '@/shared/registry/registry-utils';
 import type { RectangleNodeData } from '@/shared/types/nodes';
-import { Square as SquareIcon } from 'lucide-react';
+
+import {
+  NodeCard,
+  NodeHeader,
+  NodePortIndicator,
+  getNodeCategoryLabel,
+  getNodeCategoryVisuals,
+} from './components/node-chrome';
 
 export function RectangleNode({ data, selected }: NodeProps<RectangleNodeData>) {
   const nodeDefinition = getNodeDefinition('rectangle');
+  const category = nodeDefinition?.execution.category;
+  const visuals = getNodeCategoryVisuals(category);
+  const categoryLabel = getNodeCategoryLabel(category);
+  const width = data.width ?? (nodeDefinition?.defaults.width as number) ?? 100;
+  const height = data.height ?? (nodeDefinition?.defaults.height as number) ?? 60;
+  const aspectRatio = height === 0 ? '—' : `${Math.round((width / height) * 100) / 100}:1`;
 
   return (
-    <Card selected={selected} className="min-w-[var(--node-min-width)] p-[var(--card-padding)]">
-      <CardHeader className="p-0 pb-[var(--space-3)]">
-        <div className="flex items-center gap-[var(--space-2)]">
-          <div
-            className="flex h-6 w-6 items-center justify-center rounded text-[var(--text-primary)]"
-            style={{ backgroundColor: '#4444ff' }} // Canvas default
-          >
-            <SquareIcon size={12} />
-          </div>
-          <span className="font-semibold text-[var(--text-primary)]">
-            {data.identifier.displayName}
+    <NodeCard selected={selected}>
+      <NodeHeader
+        icon={<SquareIcon size={14} />}
+        title={data.identifier.displayName}
+        accentClassName={visuals.iconBg}
+        subtitle={categoryLabel}
+        meta={
+          <span className="text-xs text-[var(--text-secondary)]">
+            {width}px × {height}px
           </span>
+        }
+      />
+
+      <div className="space-y-[var(--space-2)] text-xs text-[var(--text-secondary)]">
+        <div className="flex items-center justify-between">
+          <span>Aspect</span>
+          <span className="font-medium text-[var(--text-primary)]">{aspectRatio}</span>
         </div>
-      </CardHeader>
+        <div className="rounded border border-dashed border-[var(--border-primary)] px-[var(--space-3)] py-[var(--space-2)] text-[11px]">
+          Emits a clean rectangle—ideal for panels, masks, or layout primitives in later nodes.
+        </div>
+      </div>
 
-      <CardContent className="space-y-1 p-0 text-xs text-[var(--text-secondary)]">
-        <div>Width: {data.width || 100}px</div>
-        <div>Height: {data.height || 60}px</div>
-      </CardContent>
-
-      {/* Single output port */}
       {nodeDefinition?.ports.outputs.map((port) => (
-        <Handle
+        <NodePortIndicator
           key={port.id}
-          type="source"
-          position={Position.Right}
           id={port.id}
-          className={`h-3 w-3 !border-2 !border-[var(--text-primary)] bg-[var(--node-geometry)]`}
-          style={{ top: `50%` }}
+          side="right"
+          type="source"
+          top="50%"
+          label="Shape output"
+          description="Passes the rectangle onward for further styling."
+          handleClassName={visuals.handle}
+          accent={category}
         />
       ))}
-    </Card>
+    </NodeCard>
   );
 }

--- a/src/components/workspace/nodes/result-node.tsx
+++ b/src/components/workspace/nodes/result-node.tsx
@@ -1,15 +1,23 @@
-// src/components/workspace/nodes/result-node.tsx - Production-ready debug node with modal viewer
+// src/components/workspace/nodes/result-node.tsx - Result/debug node UI
 'use client';
 
 import { useState } from 'react';
-import { Handle, Position, type NodeProps } from 'reactflow';
-import { Card, CardHeader, CardContent } from '@/components/ui/card';
+import type { NodeProps } from 'reactflow';
+import { Target } from 'lucide-react';
+
 import { Button } from '@/components/ui/button';
 import { getNodeDefinition } from '@/shared/registry/registry-utils';
 import type { ResultNodeData } from '@/shared/types/nodes';
-import { useDebugContext } from '../flow/debug-context';
 import { logger } from '@/lib/logger';
-import { Target } from 'lucide-react';
+
+import {
+  NodeCard,
+  NodeHeader,
+  NodePortIndicator,
+  getNodeCategoryLabel,
+  getNodeCategoryVisuals,
+} from './components/node-chrome';
+import { useDebugContext } from '../flow/debug-context';
 
 interface ResultNodeProps extends NodeProps<ResultNodeData> {
   onOpenLogViewer?: (nodeId: string) => void;
@@ -17,15 +25,16 @@ interface ResultNodeProps extends NodeProps<ResultNodeData> {
 
 export function ResultNode({ data, selected, onOpenLogViewer }: ResultNodeProps) {
   const nodeDefinition = getNodeDefinition('result');
+  const category = nodeDefinition?.execution.category;
+  const visuals = getNodeCategoryVisuals(category);
+  const categoryLabel = getNodeCategoryLabel(category);
   const [isRunning, setIsRunning] = useState(false);
 
-  // Use debug context if available
   const debugContext = useDebugContext();
   const onRunToHere = debugContext?.runToNode;
 
   const handleRunToHere = async () => {
     if (!onRunToHere) return;
-
     setIsRunning(true);
     try {
       await onRunToHere(data.identifier.id);
@@ -42,51 +51,31 @@ export function ResultNode({ data, selected, onOpenLogViewer }: ResultNodeProps)
     }
   };
 
-  const handleClass = 'bg-[var(--node-output)]';
-
   return (
-    <Card
-      selected={selected}
-      className="min-w-[var(--node-min-width)] cursor-pointer p-[var(--card-padding)] transition-all hover:bg-[var(--surface-interactive)]"
-      onDoubleClick={handleDoubleClick}
-    >
-      {/* Single input port */}
+    <NodeCard selected={selected} className="cursor-pointer" onDoubleClick={handleDoubleClick}>
       {nodeDefinition?.ports.inputs.map((port) => (
-        <Handle
+        <NodePortIndicator
           key={port.id}
+          id={port.id}
+          side="left"
           type="target"
-          position={Position.Left}
-          id={port.id}
-          className={`h-3 w-3 ${handleClass} !border-2 !border-[var(--text-primary)]`}
-          style={{ top: `35%` }}
-        />
-      ))}
-      {/* New output port to expose variable value */}
-      {nodeDefinition?.ports.outputs.map((port) => (
-        <Handle
-          key={port.id}
-          type="source"
-          position={Position.Right}
-          id={port.id}
-          className={`h-3 w-3 ${handleClass} !border-2 !border-[var(--text-primary)]`}
-          style={{ top: `35%` }}
+          top="35%"
+          label="Data to inspect"
+          description="Connect the flow you want to pause and observe."
+          handleClassName={visuals.handle}
+          accent={category}
         />
       ))}
 
-      <CardHeader className="p-0 pb-[var(--space-3)]">
-        <div className="flex items-center gap-[var(--space-2)]">
-          <div className="flex h-6 w-6 items-center justify-center rounded bg-[var(--node-output)] text-[var(--text-primary)]">
-            <Target size={12} />
-          </div>
-          <div className="min-w-0 flex-1">
-            <div className="truncate font-semibold text-[var(--text-primary)]">
-              {data.identifier.displayName}
-            </div>
-          </div>
-        </div>
-      </CardHeader>
+      <NodeHeader
+        icon={<Target size={14} />}
+        title={data.identifier.displayName}
+        accentClassName={visuals.iconBg}
+        subtitle={categoryLabel}
+        meta={<span className="text-xs text-[var(--text-secondary)]">Debug</span>}
+      />
 
-      <CardContent className="space-y-[var(--space-3)] p-0">
+      <div className="space-y-[var(--space-2)] text-xs text-[var(--text-secondary)]">
         <Button
           onClick={handleRunToHere}
           disabled={isRunning || !onRunToHere}
@@ -94,9 +83,26 @@ export function ResultNode({ data, selected, onOpenLogViewer }: ResultNodeProps)
           size="sm"
           className="w-full"
         >
-          {isRunning ? 'Running...' : 'Run to Here'}
+          {isRunning ? 'Running…' : 'Run to Here'}
         </Button>
-      </CardContent>
-    </Card>
+        <div className="rounded border border-dashed border-[var(--border-primary)] px-[var(--space-3)] py-[var(--space-2)] text-[11px]">
+          Double-click to review the latest logs for this node.
+        </div>
+      </div>
+
+      {nodeDefinition?.ports.outputs.map((port) => (
+        <NodePortIndicator
+          key={port.id}
+          id={port.id}
+          side="right"
+          type="source"
+          top="35%"
+          label="Forwarded data"
+          description="Continues the flow after inspection."
+          handleClassName={visuals.handle}
+          accent={category}
+        />
+      ))}
+    </NodeCard>
   );
 }

--- a/src/components/workspace/nodes/scene-node.tsx
+++ b/src/components/workspace/nodes/scene-node.tsx
@@ -1,14 +1,25 @@
-// src/components/workspace/nodes/scene-node.tsx - Simplified single input port
+// src/components/workspace/nodes/scene-node.tsx - Scene output node UI
 'use client';
 
-import { Handle, Position, type NodeProps } from 'reactflow';
-import { Card, CardHeader, CardContent } from '@/components/ui/card';
+import type { NodeProps } from 'reactflow';
+import { MonitorPlay } from 'lucide-react';
+
 import { getNodeDefinition } from '@/shared/registry/registry-utils';
 import type { SceneNodeData } from '@/shared/types/nodes';
-import { MonitorPlay } from 'lucide-react';
+
+import {
+  NodeCard,
+  NodeHeader,
+  NodePortIndicator,
+  getNodeCategoryLabel,
+  getNodeCategoryVisuals,
+} from './components/node-chrome';
 
 export function SceneNode({ data, selected }: NodeProps<SceneNodeData>) {
   const nodeDefinition = getNodeDefinition('scene');
+  const category = nodeDefinition?.execution.category;
+  const visuals = getNodeCategoryVisuals(category);
+  const categoryLabel = getNodeCategoryLabel(category);
 
   const getResolutionLabel = (width: number, height: number) => {
     if (width === 1920 && height === 1080) return 'FHD';
@@ -18,85 +29,53 @@ export function SceneNode({ data, selected }: NodeProps<SceneNodeData>) {
     return 'Custom';
   };
 
-  const getQualityLabel = (crf: number) => {
-    if (crf <= 18) return 'High';
-    if (crf <= 28) return 'Medium';
-    return 'Low';
-  };
-
-  const handleClass = 'bg-[var(--node-output)]';
+  const resolutionLabel = getResolutionLabel(data.width, data.height);
 
   return (
-    <Card selected={selected} className="min-w-[var(--node-min-width)] p-[var(--card-padding)]">
-      {/* Single input port */}
+    <NodeCard selected={selected}>
       {nodeDefinition?.ports.inputs.map((port) => (
-        <Handle
+        <NodePortIndicator
           key={port.id}
-          type="target"
-          position={Position.Left}
           id={port.id}
-          className={`h-3 w-3 ${handleClass} !border-2 !border-[var(--text-primary)]`}
-          style={{ top: `50%` }}
+          side="left"
+          type="target"
+          top="50%"
+          label="Final render"
+          description="Connect the animation pipeline you want to export."
+          handleClassName={visuals.handle}
+          accent={category}
         />
       ))}
 
-      <CardHeader className="p-0 pb-[var(--space-3)]">
-        <div className="flex items-center gap-[var(--space-2)]">
-          <div className="flex h-6 w-6 items-center justify-center rounded bg-[var(--node-output)] text-[var(--text-primary)]">
-            <MonitorPlay size={12} />
-          </div>
-          <div className="min-w-0 flex-1">
-            <div className="truncate font-semibold text-[var(--text-primary)]">
-              {data.identifier.displayName}
-            </div>
-          </div>
-        </div>
-      </CardHeader>
+      <NodeHeader
+        icon={<MonitorPlay size={14} />}
+        title={data.identifier.displayName}
+        accentClassName={visuals.iconBg}
+        subtitle={categoryLabel}
+        meta={
+          <span className="text-xs text-[var(--text-secondary)]">
+            {data.duration}s • {data.fps}fps
+          </span>
+        }
+      />
 
-      <CardContent className="space-y-2 p-0 text-xs text-[var(--text-secondary)]">
+      <div className="space-y-[var(--space-2)] text-xs text-[var(--text-secondary)]">
         <div className="flex items-center justify-between">
           <span>Resolution</span>
           <span className="font-medium text-[var(--text-primary)]">
-            {getResolutionLabel(data.width, data.height)} ({data.width}×{data.height})
+            {resolutionLabel} ({data.width}×{data.height})
           </span>
         </div>
-
-        <div className="flex items-center justify-between">
-          <span>Frame Rate</span>
-          <span className="font-medium text-[var(--text-primary)]">{data.fps} FPS</span>
-        </div>
-
-        <div className="flex items-center justify-between">
-          <span>Duration</span>
-          <span className="font-medium text-[var(--text-primary)]">{data.duration}s</span>
-        </div>
-
         <div className="flex items-center justify-between">
           <span>Background</span>
-          <div className="flex items-center gap-[var(--space-2)]">
-            <div
-              className="h-4 w-4 rounded border border-[var(--border-primary)]"
-              style={{ backgroundColor: data.backgroundColor }}
-            />
-            <span className="text-xs font-medium text-[var(--text-primary)]">
-              {data.backgroundColor.toUpperCase()}
-            </span>
-          </div>
-        </div>
-
-        <div className="flex items-center justify-between">
-          <span>Quality</span>
           <span className="font-medium text-[var(--text-primary)]">
-            {getQualityLabel(data.videoCrf)} ({data.videoPreset})
+            {data.backgroundColor.toUpperCase()}
           </span>
         </div>
-
-        <div className="mt-4 border-t border-[var(--border-primary)] pt-3">
-          <div className="text-center text-xs text-[var(--text-tertiary)]">
-            {data.width}×{data.height} @ {data.fps}fps
-          </div>
+        <div className="rounded border border-dashed border-[var(--border-primary)] px-[var(--space-3)] py-[var(--space-2)] text-[11px]">
+          Configure quality and preset options here before exporting your final video.
         </div>
-      </CardContent>
-    </Card>
+      </div>
+    </NodeCard>
   );
 }

--- a/src/components/workspace/nodes/text-node.tsx
+++ b/src/components/workspace/nodes/text-node.tsx
@@ -1,49 +1,62 @@
+// src/components/workspace/nodes/text-node.tsx - Text source node UI
 'use client';
 
-import { Handle, Position, type NodeProps } from 'reactflow';
-import { Card, CardHeader, CardContent } from '@/components/ui/card';
+import type { NodeProps } from 'reactflow';
+import { Type } from 'lucide-react';
+
 import { getNodeDefinition } from '@/shared/registry/registry-utils';
 import type { TextNodeData } from '@/shared/types/nodes';
-import { Type } from 'lucide-react';
+
+import {
+  NodeCard,
+  NodeHeader,
+  NodePortIndicator,
+  getNodeCategoryLabel,
+  getNodeCategoryVisuals,
+} from './components/node-chrome';
 
 export function TextNode({ data, selected }: NodeProps<TextNodeData>) {
   const nodeDefinition = getNodeDefinition('text');
+  const category = nodeDefinition?.execution.category;
+  const visuals = getNodeCategoryVisuals(category);
+  const categoryLabel = getNodeCategoryLabel(category);
 
-  const displayContent =
-    data.content?.length > 20
-      ? data.content.substring(0, 20) + '...'
-      : data.content || 'Hello World';
+  const content = data.content?.trim() ?? 'Hello World';
+  const previewContent = content.length > 40 ? `${content.slice(0, 37)}…` : content;
+  const fontSize = data.fontSize ?? (nodeDefinition?.defaults.fontSize as number) ?? 24;
 
   return (
-    <Card selected={selected} className="min-w-[var(--node-min-width)] p-[var(--card-padding)]">
-      <CardHeader className="p-0 pb-[var(--space-3)]">
-        <div className="flex items-center gap-[var(--space-2)]">
-          <div className="flex h-6 w-6 items-center justify-center rounded bg-[var(--node-text)] text-[var(--text-primary)]">
-            <Type size={12} />
-          </div>
-          <span className="font-semibold text-[var(--text-primary)]">
-            {data.identifier.displayName}
-          </span>
-        </div>
-      </CardHeader>
+    <NodeCard selected={selected}>
+      <NodeHeader
+        icon={<Type size={14} />}
+        title={data.identifier.displayName}
+        accentClassName={visuals.iconBg}
+        subtitle={categoryLabel}
+        meta={<span className="text-xs text-[var(--text-secondary)]">{fontSize}px</span>}
+      />
 
-      <CardContent className="space-y-1 p-0 text-xs text-[var(--text-secondary)]">
-        <div className="rounded bg-[var(--surface-2)] p-1 font-mono text-[10px]">
-          &ldquo;{displayContent}&rdquo;
+      <div className="space-y-[var(--space-2)] text-xs text-[var(--text-secondary)]">
+        <div className="rounded border border-[var(--border-primary)] bg-[var(--surface-2)] px-[var(--space-3)] py-[var(--space-2)] text-[var(--text-primary)]">
+          “{previewContent}”
         </div>
-        <div>Size: {data.fontSize || 24}px</div>
-      </CardContent>
+        <div className="rounded border border-dashed border-[var(--border-primary)] px-[var(--space-3)] py-[var(--space-2)] text-[11px]">
+          Source plain text that can be styled, animated, or duplicated further down the graph.
+        </div>
+      </div>
 
       {nodeDefinition?.ports.outputs.map((port) => (
-        <Handle
+        <NodePortIndicator
           key={port.id}
-          type="source"
-          position={Position.Right}
           id={port.id}
-          className="h-3 w-3 !border-2 !border-[var(--text-primary)] bg-[var(--node-text)]"
-          style={{ top: '50%' }}
+          side="right"
+          type="source"
+          top="50%"
+          label="Text output"
+          description="Sends this text element to the next node."
+          handleClassName={visuals.handle}
+          accent={category}
         />
       ))}
-    </Card>
+    </NodeCard>
   );
 }

--- a/src/components/workspace/nodes/triangle-node.tsx
+++ b/src/components/workspace/nodes/triangle-node.tsx
@@ -1,46 +1,61 @@
 // src/components/workspace/nodes/triangle-node.tsx - Simplified single output port
+
 'use client';
 
-import { Handle, Position, type NodeProps } from 'reactflow';
-import { Card, CardHeader, CardContent } from '@/components/ui/card';
+import type { NodeProps } from 'reactflow';
+import { Triangle as TriangleIcon } from 'lucide-react';
+
 import { getNodeDefinition } from '@/shared/registry/registry-utils';
 import type { TriangleNodeData } from '@/shared/types/nodes';
-import { Triangle as TriangleIcon } from 'lucide-react';
+
+import {
+  NodeCard,
+  NodeHeader,
+  NodePortIndicator,
+  getNodeCategoryLabel,
+  getNodeCategoryVisuals,
+} from './components/node-chrome';
 
 export function TriangleNode({ data, selected }: NodeProps<TriangleNodeData>) {
   const nodeDefinition = getNodeDefinition('triangle');
+  const category = nodeDefinition?.execution.category;
+  const visuals = getNodeCategoryVisuals(category);
+  const categoryLabel = getNodeCategoryLabel(category);
+  const size = data.size ?? (nodeDefinition?.defaults.size as number) ?? 80;
 
   return (
-    <Card selected={selected} className="min-w-[var(--node-min-width)] p-[var(--card-padding)]">
-      <CardHeader className="p-0 pb-[var(--space-3)]">
-        <div className="flex items-center gap-[var(--space-2)]">
-          <div
-            className="flex h-6 w-6 items-center justify-center rounded text-[var(--text-primary)]"
-            style={{ backgroundColor: '#4444ff' }} // Canvas default
-          >
-            <TriangleIcon size={12} />
-          </div>
-          <span className="font-semibold text-[var(--text-primary)]">
-            {data.identifier.displayName}
-          </span>
+    <NodeCard selected={selected}>
+      <NodeHeader
+        icon={<TriangleIcon size={14} />}
+        title={data.identifier.displayName}
+        accentClassName={visuals.iconBg}
+        subtitle={categoryLabel}
+        meta={<span className="text-xs text-[var(--text-secondary)]">Side {size}px</span>}
+      />
+
+      <div className="space-y-[var(--space-2)] text-xs text-[var(--text-secondary)]">
+        <div className="flex items-center justify-between">
+          <span>Orientation</span>
+          <span className="font-medium text-[var(--text-primary)]">Centered upright</span>
         </div>
-      </CardHeader>
+        <div className="rounded border border-dashed border-[var(--border-primary)] px-[var(--space-3)] py-[var(--space-2)] text-[11px]">
+          Emits a crisp triangle ready for styling, animation, or duplication downstream.
+        </div>
+      </div>
 
-      <CardContent className="space-y-1 p-0 text-xs text-[var(--text-secondary)]">
-        <div>Size: {data.size || 80}px</div>
-      </CardContent>
-
-      {/* Single output port */}
       {nodeDefinition?.ports.outputs.map((port) => (
-        <Handle
+        <NodePortIndicator
           key={port.id}
-          type="source"
-          position={Position.Right}
           id={port.id}
-          className={`h-3 w-3 !border-2 !border-[var(--text-primary)] bg-[var(--node-geometry)]`}
-          style={{ top: `50%` }}
+          side="right"
+          type="source"
+          top="50%"
+          label="Shape output"
+          description="Passes the triangle to the next node."
+          handleClassName={visuals.handle}
+          accent={category}
         />
       ))}
-    </Card>
+    </NodeCard>
   );
 }

--- a/src/components/workspace/nodes/typography-node.tsx
+++ b/src/components/workspace/nodes/typography-node.tsx
@@ -1,10 +1,19 @@
+// src/components/workspace/nodes/typography-node.tsx - Typography node UI
 'use client';
 
-import { Handle, Position, type NodeProps } from 'reactflow';
-import { Card, CardHeader, CardContent } from '@/components/ui/card';
+import type { NodeProps } from 'reactflow';
+import { Type, SlidersHorizontal } from 'lucide-react';
+
 import { getNodeDefinition } from '@/shared/registry/registry-utils';
 import type { TypographyNodeData } from '@/shared/types/nodes';
-import { Type, Settings } from 'lucide-react';
+
+import {
+  NodeCard,
+  NodeHeader,
+  NodePortIndicator,
+  getNodeCategoryLabel,
+  getNodeCategoryVisuals,
+} from './components/node-chrome';
 
 interface TypographyNodeProps extends NodeProps<TypographyNodeData> {
   onOpenTypography?: () => void;
@@ -12,11 +21,15 @@ interface TypographyNodeProps extends NodeProps<TypographyNodeData> {
 
 export function TypographyNode({ data, selected, onOpenTypography }: TypographyNodeProps) {
   const nodeDefinition = getNodeDefinition('typography');
+  const category = nodeDefinition?.execution.category;
+  const visuals = getNodeCategoryVisuals(category);
+  const categoryLabel = getNodeCategoryLabel(category);
 
   const handleDoubleClick = () => {
-    if (onOpenTypography) return onOpenTypography();
-
-    // Fallback URL navigation (follows AnimationNode pattern)
+    if (onOpenTypography) {
+      onOpenTypography();
+      return;
+    }
     const params = new URLSearchParams(window.location.search);
     const ws = params.get('workspace');
     const url = new URL(window.location.href);
@@ -29,55 +42,63 @@ export function TypographyNode({ data, selected, onOpenTypography }: TypographyN
   const currentFont = `${data.fontFamily || 'Arial'} ${data.fontWeight || 'normal'}`;
 
   return (
-    <Card
-      selected={selected}
-      className="min-w-[var(--node-min-width)] cursor-pointer p-[var(--card-padding)] transition-all hover:bg-[var(--surface-interactive)]"
-      onDoubleClick={handleDoubleClick}
-    >
+    <NodeCard selected={selected} className="cursor-pointer" onDoubleClick={handleDoubleClick}>
       {nodeDefinition?.ports.inputs.map((port) => (
-        <Handle
+        <NodePortIndicator
           key={port.id}
-          type="target"
-          position={Position.Left}
           id={port.id}
-          className="h-3 w-3 !border-2 !border-[var(--text-primary)] bg-[var(--node-animation)]"
-          style={{ top: '50%' }}
+          side="left"
+          type="target"
+          top="50%"
+          label="Text to style"
+          description="Feed in the text elements you want to format."
+          handleClassName={visuals.handle}
+          accent={category}
         />
       ))}
 
-      <CardHeader className="p-0 pb-[var(--space-3)]">
-        <div className="flex items-center gap-[var(--space-2)]">
-          <div className="flex h-6 w-6 items-center justify-center rounded bg-[var(--node-animation)] text-[var(--text-primary)]">
-            <Type size={12} />
-          </div>
-          <div className="min-w-0 flex-1">
-            <div className="truncate font-semibold text-[var(--text-primary)]">
-              {data?.identifier?.displayName ?? 'Typography'}
-            </div>
-          </div>
-          <Settings size={12} className="text-[var(--text-tertiary)]" />
-        </div>
-      </CardHeader>
+      <NodeHeader
+        icon={<Type size={14} />}
+        title={data?.identifier?.displayName ?? 'Typography'}
+        accentClassName={visuals.iconBg}
+        subtitle={categoryLabel}
+        meta={
+          <span className="flex items-center gap-[var(--space-1)] text-xs text-[var(--text-secondary)]">
+            <SlidersHorizontal size={12} />
+            {currentFont}
+          </span>
+        }
+      />
 
-      <CardContent className="space-y-1 p-0 text-xs text-[var(--text-secondary)]">
-        <div className="truncate">Font: {currentFont}</div>
-        <div>Align: {data.textAlign || 'center'}</div>
-        <div>Line Height: {data.lineHeight || 1.2}</div>
-        <div className="pt-1 text-[10px] text-[var(--text-tertiary)]">
-          Double-click to edit in Typography tab
+      <div className="space-y-[var(--space-2)] text-xs text-[var(--text-secondary)]">
+        <div className="flex items-center justify-between">
+          <span>Alignment</span>
+          <span className="font-medium text-[var(--text-primary)]">
+            {data.textAlign || 'center'}
+          </span>
         </div>
-      </CardContent>
+        <div className="flex items-center justify-between">
+          <span>Line height</span>
+          <span className="font-medium text-[var(--text-primary)]">{data.lineHeight ?? 1.2}</span>
+        </div>
+        <div className="rounded border border-dashed border-[var(--border-primary)] px-[var(--space-3)] py-[var(--space-2)] text-[11px]">
+          Double-click to fine tune fonts, spacing, and color in the typography panel.
+        </div>
+      </div>
 
       {nodeDefinition?.ports.outputs.map((port) => (
-        <Handle
+        <NodePortIndicator
           key={port.id}
-          type="source"
-          position={Position.Right}
           id={port.id}
-          className="h-3 w-3 !border-2 !border-[var(--text-primary)] bg-[var(--node-animation)]"
-          style={{ top: '50%' }}
+          side="right"
+          type="source"
+          top="50%"
+          label="Styled text"
+          description="Outputs the text with the configured typography applied."
+          handleClassName={visuals.handle}
+          accent={category}
         />
       ))}
-    </Card>
+    </NodeCard>
   );
 }


### PR DESCRIPTION
## Summary
- add a shared node chrome component that standardizes card layout, headers, category visuals, and labeled port indicators across workspace nodes
- migrate every workspace node to the new chrome so each port exposes a clear, plain-language label without changing wiring or behavior
- preserve existing interactions by supporting handle double-clicks and safe positioning logic for dynamic port counts

## Testing
- pnpm exec prettier --check "src/components/workspace/nodes/**/*.tsx"
- pnpm typecheck
- pnpm check *(fails: Prettier reports formatting drift in src/app/_components/early-access-form.tsx outside this scope)*
- pnpm lint *(fails: Next.js env validation requires SUPABASE and database secrets in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce66e5ca9c8322aec54aae0b0f6441