### PR TITLE
Improve workspace node layout and port labeling

### DIFF
--- a/src/components/workspace/nodes/animation-node.tsx
+++ b/src/components/workspace/nodes/animation-node.tsx
@@ -1,8 +1,10 @@
-// src/components/workspace/nodes/animation-node.tsx - Simplified single input/output ports
+// src/components/workspace/nodes/animation-node.tsx - Animation timeline node with structured layout
 'use client';
 
-import { Handle, Position, type NodeProps } from 'reactflow';
-import { Card, CardHeader, CardContent } from '@/components/ui/card';
+import type { NodeProps } from 'reactflow';
+
+import { NodeLayout } from './node-layout';
+import { buildPortDisplays } from './port-utils';
 import { transformFactory } from '@/shared/registry/transforms';
 import { getNodeDefinition } from '@/shared/registry/registry-utils';
 import type { AnimationNodeData } from '@/shared/types/nodes';
@@ -15,9 +17,26 @@ interface AnimationNodeProps extends NodeProps<AnimationNodeData> {
 export function AnimationNode({ data, selected, onOpenTimeline }: AnimationNodeProps) {
   const nodeDefinition = getNodeDefinition('animation');
 
+  const inputs = buildPortDisplays(nodeDefinition?.ports.inputs, 'input', {
+    input: {
+      label: 'Objects to animate',
+      description: 'Attach text, shapes, or media objects that need animation.',
+    },
+  });
+
+  const outputs = buildPortDisplays(nodeDefinition?.ports.outputs, 'output', {
+    output: {
+      label: 'Animated object stream',
+      description: 'Delivers animated objects downstream for further styling.',
+    },
+  });
+
   const handleDoubleClick = () => {
-    if (onOpenTimeline) return onOpenTimeline();
-    // Fallback: navigate to dedicated timeline editor page preserving workspace
+    if (onOpenTimeline) {
+      onOpenTimeline();
+      return;
+    }
+
     const params = new URLSearchParams(window.location.search);
     const ws = params.get('workspace');
     const url = new URL(window.location.href);
@@ -27,83 +46,46 @@ export function AnimationNode({ data, selected, onOpenTimeline }: AnimationNodeP
     window.history.pushState({}, '', url.toString());
   };
 
-  const trackCount = data.tracks?.length || 0;
-  const trackTypes = data.tracks?.map((t) => t.type) || [];
+  const trackCount = data.tracks?.length ?? 0;
+  const trackTypes = data.tracks?.map((t) => t.type) ?? [];
   const uniqueTypes = [...new Set(trackTypes)];
 
-  const handleClass = 'bg-[var(--node-animation)]';
-
+  const durationLabel = `${data.duration ?? 3}s`;
   return (
-    <Card
+    <NodeLayout
       selected={selected}
-      className="min-w-[var(--node-min-width)] cursor-pointer p-[var(--card-padding)] transition-all hover:bg-[var(--surface-interactive)]"
+      className="cursor-pointer transition-colors hover:bg-[var(--surface-interactive)]"
+      title={data.identifier.displayName}
+      subtitle={trackCount > 0 ? `${trackCount} track${trackCount === 1 ? '' : 's'}` : 'No tracks yet'}
+      icon={<Clapperboard className="h-3 w-3" />}
+      iconBackgroundClass="bg-[var(--node-animation)] text-[var(--text-primary)]"
+      headerAside={<span className="font-medium text-[var(--text-primary)]">{durationLabel}</span>}
+      inputs={inputs}
+      outputs={outputs}
+      accentHandleClass="!bg-[var(--node-animation)]"
       onDoubleClick={handleDoubleClick}
+      footer="Double-click to open the Timeline editor"
     >
-      {/* Single input port */}
-      {nodeDefinition?.ports.inputs.map((port) => (
-        <Handle
-          key={port.id}
-          type="target"
-          position={Position.Left}
-          id={port.id}
-          className={`h-3 w-3 ${handleClass} !border-2 !border-[var(--text-primary)]`}
-          style={{ top: `50%` }}
-        />
-      ))}
-
-      <CardHeader className="p-0 pb-[var(--space-3)]">
-        <div className="flex items-center justify-between">
-          <div className="flex min-w-0 flex-1 items-center gap-[var(--space-2)]">
-            <div className="flex h-6 w-6 items-center justify-center rounded bg-[var(--node-animation)] text-[var(--text-primary)]">
-              <Clapperboard size={12} />
-            </div>
-            <span className="font-semibold text-[var(--text-primary)]">
-              {data.identifier.displayName}
+      <div className="flex items-center justify-between text-xs">
+        <span>Total tracks</span>
+        <span className="font-medium text-[var(--text-primary)]">{trackCount}</span>
+      </div>
+      {trackCount > 0 ? (
+        <div className="flex flex-wrap gap-1">
+          {uniqueTypes.map((type) => (
+            <span
+              key={type}
+              className={`rounded-[var(--radius-sm)] px-[var(--space-2)] py-[var(--space-half)] text-[10px] text-[var(--text-primary)] ${
+                transformFactory.getTrackColors()[type] ?? 'bg-[var(--surface-2)]'
+              }`}
+            >
+              {transformFactory.getTrackIcons()[type] ?? '●'} {type}
             </span>
-          </div>
-          <div className="text-xs text-[var(--text-tertiary)]">{data.duration}s</div>
+          ))}
         </div>
-      </CardHeader>
-
-      <CardContent className="space-y-[var(--space-2)] p-0">
-        <div className="flex items-center justify-between">
-          <span className="text-xs text-[var(--text-secondary)]">Tracks:</span>
-          <span className="text-xs font-medium text-[var(--text-primary)]">{trackCount}</span>
-        </div>
-
-        {trackCount > 0 && (
-          <div className="flex flex-wrap gap-1">
-            {uniqueTypes.map((type) => (
-              <span
-                key={type}
-                className={`rounded-[var(--radius-sharp)] px-[var(--space-2)] py-[var(--space-1)] text-xs ${transformFactory.getTrackColors()[type] ?? 'bg-[var(--surface-2)]'} text-[var(--text-primary)]`}
-              >
-                {transformFactory.getTrackIcons()[type] ?? '●'} {type}
-              </span>
-            ))}
-          </div>
-        )}
-
-        {trackCount === 0 && (
-          <div className="py-2 text-center text-xs text-[var(--text-tertiary)]">No tracks</div>
-        )}
-
-        <div className="pt-1 text-[10px] text-[var(--text-tertiary)]">
-          Variables can be bound in the timeline editor
-        </div>
-      </CardContent>
-
-      {/* Single output port */}
-      {nodeDefinition?.ports.outputs.map((port) => (
-        <Handle
-          key={port.id}
-          type="source"
-          position={Position.Right}
-          id={port.id}
-          className={`h-3 w-3 ${handleClass} !border-2 !border-[var(--text-primary)]`}
-          style={{ top: `50%` }}
-        />
-      ))}
-    </Card>
+      ) : (
+        <div className="text-xs text-[var(--text-tertiary)]">Timeline is empty</div>
+      )}
+    </NodeLayout>
   );
 }

--- a/src/components/workspace/nodes/boolean-op-node.tsx
+++ b/src/components/workspace/nodes/boolean-op-node.tsx
@@ -1,8 +1,10 @@
-// src/components/workspace/nodes/boolean-op-node.tsx - Boolean operation logic node
+// src/components/workspace/nodes/boolean-op-node.tsx - Boolean operation node with structured layout
 'use client';
 
-import { Handle, Position, type NodeProps } from 'reactflow';
-import { Card, CardHeader, CardContent } from '@/components/ui/card';
+import type { NodeProps } from 'reactflow';
+
+import { NodeLayout, type NodePortDisplay } from './node-layout';
+import { buildPortDisplays } from './port-utils';
 import { getNodeDefinitionWithDynamicPorts } from '@/shared/registry/registry-utils';
 import type { BooleanOpNodeData } from '@/shared/types/nodes';
 import { Binary } from 'lucide-react';
@@ -13,100 +15,66 @@ export function BooleanOpNode({ data, selected }: NodeProps<BooleanOpNodeData>) 
     data as unknown as Record<string, unknown>
   );
 
-  const getOperatorDisplay = () => {
-    switch (data.operator) {
-      case 'and':
-        return 'AND';
-      case 'or':
-        return 'OR';
-      case 'not':
-        return 'NOT';
-      case 'xor':
-        return 'XOR';
-    }
+  const OPERATOR_DISPLAY: Record<BooleanOpNodeData['operator'], string> = {
+    and: 'AND',
+    or: 'OR',
+    not: 'NOT',
+    xor: 'XOR',
   };
 
-  const getOperatorSymbol = () => {
-    switch (data.operator) {
-      case 'and':
-        return '∧';
-      case 'or':
-        return '∨';
-      case 'not':
-        return '¬';
-      case 'xor':
-        return '⊕';
-    }
+  const OPERATOR_SYMBOL: Record<BooleanOpNodeData['operator'], string> = {
+    and: '∧',
+    or: '∨',
+    not: '¬',
+    xor: '⊕',
   };
 
-  const handleClass = 'bg-[var(--node-logic)]';
+  const getOperatorDisplay = () => OPERATOR_DISPLAY[data.operator];
+  const getOperatorSymbol = () => OPERATOR_SYMBOL[data.operator];
+
+  const inputPorts: NodePortDisplay[] = (nodeDefinition?.ports.inputs ?? []).map((port, index) => ({
+    id: port.id,
+    label:
+      data.operator === 'not'
+        ? 'Boolean input'
+        : index === 0
+          ? 'Condition A'
+          : 'Condition B',
+    description: 'Provide boolean values to evaluate.',
+  }));
+
+  const outputs = buildPortDisplays(nodeDefinition?.ports.outputs, 'output', {
+    output: {
+      label: 'Boolean result',
+      description: 'Outputs the evaluated boolean value.',
+    },
+  });
+
+  const subtitle = `Operation: ${getOperatorDisplay()}`;
 
   return (
-    <Card selected={selected} className="min-w-[var(--node-min-width)] p-[var(--card-padding)]">
-      {/* Dynamic input ports */}
-      {nodeDefinition?.ports.inputs.map((port, index) => (
-        <Handle
-          key={port.id}
-          type="target"
-          position={Position.Left}
-          id={port.id}
-          className={`h-3 w-3 ${handleClass} !border-2 !border-[var(--text-primary)]`}
-          style={{ top: `${35 + index * 30}%` }}
-        />
-      ))}
-
-      <CardHeader className="p-0 pb-[var(--space-3)]">
-        <div className="flex items-center gap-[var(--space-2)]">
-          <div className="flex h-6 w-6 items-center justify-center rounded bg-[var(--node-logic)] text-[var(--text-primary)]">
-            <Binary size={12} />
-          </div>
-          <span className="font-semibold text-[var(--text-primary)]">
-            {data.identifier.displayName}
-          </span>
+    <NodeLayout
+      selected={selected}
+      title={data.identifier.displayName}
+      subtitle={subtitle}
+      icon={<Binary className="h-3 w-3" />}
+      iconBackgroundClass="bg-[var(--node-logic)] text-[var(--text-primary)]"
+      inputs={inputPorts}
+      outputs={outputs}
+      accentHandleClass="!bg-[var(--node-logic)]"
+    >
+      <div className="rounded border border-[var(--border-primary)] bg-[var(--surface-2)] p-2 text-center">
+        <div className="font-mono text-sm text-[var(--text-primary)]">Bool ({getOperatorDisplay()})</div>
+        <div className="mt-1 font-mono text-lg text-[var(--text-primary)]">
+          {data.operator === 'not' ? `${getOperatorSymbol()}A` : `A ${getOperatorSymbol()} B`}
         </div>
-      </CardHeader>
-
-      <CardContent className="space-y-2 p-0">
-        <div className="rounded border border-[var(--border-primary)] bg-[var(--surface-2)] p-2 text-center">
-          <div className="font-mono text-sm text-[var(--text-primary)]">
-            Bool ({getOperatorDisplay()})
-          </div>
-          <div className="mt-1 font-mono text-lg text-[var(--text-primary)]">
-            {data.operator === 'not' ? `${getOperatorSymbol()}A` : `A ${getOperatorSymbol()} B`}
-          </div>
-        </div>
-
-        <div className="flex items-center justify-between">
-          <span className="text-xs text-[var(--text-secondary)]">Operation:</span>
-          <span className="text-xs font-medium text-[var(--text-primary)]">
-            {getOperatorDisplay()}
-          </span>
-        </div>
-
-        <div className="text-center text-xs">
-          <span className="rounded-[var(--radius-sm)] bg-[var(--accent-100)] px-[var(--space-2)] py-[var(--space-1)] text-[var(--accent-900)]">
-            Boolean Logic
-          </span>
-        </div>
-
-        <div className="mt-3 border-t border-[var(--border-primary)] pt-2">
-          <div className="text-center text-xs text-[var(--text-tertiary)]">
-            {data.operator === 'not' ? '1 Input' : '2 Inputs'} → Boolean
-          </div>
-        </div>
-      </CardContent>
-
-      {/* Output port */}
-      {nodeDefinition?.ports.outputs.map((port) => (
-        <Handle
-          key={port.id}
-          type="source"
-          position={Position.Right}
-          id={port.id}
-          className={`h-3 w-3 ${handleClass} !border-2 !border-[var(--text-primary)]`}
-          style={{ top: '50%' }}
-        />
-      ))}
-    </Card>
+      </div>
+      <div className="flex items-center justify-between text-xs">
+        <span>Inputs</span>
+        <span className="font-medium text-[var(--text-primary)]">
+          {data.operator === 'not' ? '1 boolean' : '2 booleans'}
+        </span>
+      </div>
+    </NodeLayout>
   );
 }

--- a/src/components/workspace/nodes/canvas-node.tsx
+++ b/src/components/workspace/nodes/canvas-node.tsx
@@ -1,8 +1,9 @@
-// src/components/workspace/nodes/canvas-node.tsx
 'use client';
 
-import { Handle, Position, type NodeProps } from 'reactflow';
-import { Card, CardHeader, CardContent } from '@/components/ui/card';
+import type { NodeProps } from 'reactflow';
+
+import { NodeLayout } from './node-layout';
+import { buildPortDisplays } from './port-utils';
 import { getNodeDefinition } from '@/shared/registry/registry-utils';
 import type { CanvasNodeData } from '@/shared/types/nodes';
 import { Palette } from 'lucide-react';
@@ -14,8 +15,26 @@ type CanvasNodeProps = NodeProps<CanvasNodeData> & {
 export function CanvasNode({ data, selected, onOpenCanvas }: CanvasNodeProps) {
   const nodeDefinition = getNodeDefinition('canvas');
 
+  const inputs = buildPortDisplays(nodeDefinition?.ports.inputs, 'input', {
+    input: {
+      label: 'Objects to style',
+      description: 'Connect shapes, text, or media to apply static styling.',
+    },
+  });
+
+  const outputs = buildPortDisplays(nodeDefinition?.ports.outputs, 'output', {
+    output: {
+      label: 'Styled objects',
+      description: 'Outputs objects with the canvas styling applied.',
+    },
+  });
+
   const handleDoubleClick = () => {
-    if (onOpenCanvas) return onOpenCanvas();
+    if (onOpenCanvas) {
+      onOpenCanvas();
+      return;
+    }
+
     const params = new URLSearchParams(window.location.search);
     const ws = params.get('workspace');
     const url = new URL(window.location.href);
@@ -25,53 +44,23 @@ export function CanvasNode({ data, selected, onOpenCanvas }: CanvasNodeProps) {
     window.history.pushState({}, '', url.toString());
   };
 
-  const handleClass = 'bg-[var(--node-geometry)]';
-
   return (
-    <Card
+    <NodeLayout
       selected={selected}
-      className="min-w-[var(--node-min-width)] cursor-pointer p-[var(--card-padding)] transition-all hover:bg-[var(--surface-interactive)]"
+      className="cursor-pointer transition-colors hover:bg-[var(--surface-interactive)]"
+      title={data?.identifier?.displayName ?? 'Canvas'}
+      subtitle="Static styling adjustments"
+      icon={<Palette className="h-3 w-3" />}
+      iconBackgroundClass="bg-[var(--node-geometry)] text-[var(--text-primary)]"
+      inputs={inputs}
+      outputs={outputs}
+      accentHandleClass="!bg-[var(--node-geometry)]"
       onDoubleClick={handleDoubleClick}
+      footer="Double-click to edit in the Canvas tab"
     >
-      {nodeDefinition?.ports.inputs.map((port) => (
-        <Handle
-          key={port.id}
-          type="target"
-          position={Position.Left}
-          id={port.id}
-          className={`h-3 w-3 ${handleClass} !border-2 !border-[var(--text-primary)]`}
-          style={{ top: `50%` }}
-        />
-      ))}
-      {nodeDefinition?.ports.outputs.map((port, idx) => (
-        <Handle
-          key={port.id}
-          type="source"
-          position={Position.Right}
-          id={port.id}
-          className={`h-3 w-3 ${handleClass} !border-2 !border-[var(--text-primary)]`}
-          style={{ top: `${50 + idx * 16}%` }}
-        />
-      ))}
-
-      <CardHeader className="p-0 pb-[var(--space-3)]">
-        <div className="flex items-center gap-[var(--space-2)]">
-          <div className="flex h-6 w-6 items-center justify-center rounded bg-[var(--node-geometry)] text-[var(--text-primary)]">
-            <Palette size={12} />
-          </div>
-          <div className="min-w-0 flex-1">
-            <div className="truncate font-semibold text-[var(--text-primary)]">
-              {data?.identifier?.displayName ?? 'Canvas'}
-            </div>
-          </div>
-        </div>
-      </CardHeader>
-
-      <CardContent className="space-y-2 p-0 text-xs text-[var(--text-secondary)]">
-        <div className="pt-1 text-[10px] text-[var(--text-tertiary)]">
-          Double-click to edit in Canvas tab
-        </div>
-      </CardContent>
-    </Card>
+      <div className="text-xs text-[var(--text-secondary)]">
+        Use the Canvas editor to fine-tune fill, stroke, and transforms.
+      </div>
+    </NodeLayout>
   );
 }

--- a/src/components/workspace/nodes/circle-node.tsx
+++ b/src/components/workspace/nodes/circle-node.tsx
@@ -1,46 +1,41 @@
-// src/components/workspace/nodes/circle-node.tsx - Simplified single output port
+// src/components/workspace/nodes/circle-node.tsx - Geometry circle node with structured layout
 'use client';
 
-import { Handle, Position, type NodeProps } from 'reactflow';
-import { Card, CardHeader, CardContent } from '@/components/ui/card';
+import type { NodeProps } from 'reactflow';
+
+import { NodeLayout } from './node-layout';
+import { buildPortDisplays } from './port-utils';
 import { getNodeDefinition } from '@/shared/registry/registry-utils';
 import type { CircleNodeData } from '@/shared/types/nodes';
 import { Circle as CircleIcon } from 'lucide-react';
 
 export function CircleNode({ data, selected }: NodeProps<CircleNodeData>) {
   const nodeDefinition = getNodeDefinition('circle');
+  const outputs = buildPortDisplays(nodeDefinition?.ports.outputs, 'output', {
+    output: {
+      label: 'Circle shape for composition',
+      description: 'Emits a circle geometry you can animate, style, or merge with other shapes.',
+    },
+  });
+
+  const radius = data.radius ?? 50;
+  const subtitle = `Radius ${radius}px`;
 
   return (
-    <Card selected={selected} className="min-w-[var(--node-min-width)] p-[var(--card-padding)]">
-      <CardHeader className="p-0 pb-[var(--space-3)]">
-        <div className="flex items-center gap-[var(--space-2)]">
-          <div
-            className="flex h-6 w-6 items-center justify-center rounded text-[var(--text-primary)]"
-            style={{ backgroundColor: '#4444ff' }} // Canvas default
-          >
-            <CircleIcon size={12} />
-          </div>
-          <span className="font-semibold text-[var(--text-primary)]">
-            {data.identifier.displayName}
-          </span>
-        </div>
-      </CardHeader>
-
-      <CardContent className="space-y-1 p-0 text-xs text-[var(--text-secondary)]">
-        <div>Radius: {data.radius || 50}px</div>
-      </CardContent>
-
-      {/* Single output port */}
-      {nodeDefinition?.ports.outputs.map((port) => (
-        <Handle
-          key={port.id}
-          type="source"
-          position={Position.Right}
-          id={port.id}
-          className={`h-3 w-3 !border-2 !border-[var(--text-primary)] bg-[var(--node-geometry)]`}
-          style={{ top: `50%` }}
-        />
-      ))}
-    </Card>
+    <NodeLayout
+      selected={selected}
+      title={data.identifier.displayName}
+      subtitle={subtitle}
+      icon={<CircleIcon className="h-3 w-3" />}
+      iconBackgroundClass="bg-[var(--node-geometry)] text-[var(--text-primary)]"
+      inputs={[]}
+      outputs={outputs}
+      accentHandleClass="!bg-[var(--node-geometry)]"
+    >
+      <div className="flex items-center justify-between text-xs">
+        <span>Fill</span>
+        <span className="font-medium text-[var(--text-primary)]">Workspace accent</span>
+      </div>
+    </NodeLayout>
   );
 }

--- a/src/components/workspace/nodes/compare-node.tsx
+++ b/src/components/workspace/nodes/compare-node.tsx
@@ -1,8 +1,9 @@
-// src/components/workspace/nodes/compare-node.tsx - Compare logic node
 'use client';
 
-import { Handle, Position, type NodeProps } from 'reactflow';
-import { Card, CardHeader, CardContent } from '@/components/ui/card';
+import type { NodeProps } from 'reactflow';
+
+import { NodeLayout, type NodePortDisplay } from './node-layout';
+import { buildPortDisplays } from './port-utils';
 import { getNodeDefinition } from '@/shared/registry/registry-utils';
 import type { CompareNodeData } from '@/shared/types/nodes';
 import { Equal } from 'lucide-react';
@@ -24,6 +25,8 @@ export function CompareNode({ data, selected }: NodeProps<CompareNodeData>) {
         return '>=';
       case 'lte':
         return '<=';
+      default:
+        return '?';
     }
   };
 
@@ -41,74 +44,44 @@ export function CompareNode({ data, selected }: NodeProps<CompareNodeData>) {
         return 'Greater or equal';
       case 'lte':
         return 'Less or equal';
+      default:
+        return 'Comparison';
     }
   };
 
-  const handleClass = 'bg-[var(--node-logic)]';
+  const inputs: NodePortDisplay[] = (nodeDefinition?.ports.inputs ?? []).map((port, index) => ({
+    id: port.id,
+    label: index === 0 ? 'Value A' : 'Value B',
+    description: 'Supply the values to compare.',
+  }));
+
+  const outputs = buildPortDisplays(nodeDefinition?.ports.outputs, 'output', {
+    output: {
+      label: 'Comparison result',
+      description: 'Outputs true or false based on the comparison.',
+    },
+  });
+
+  const subtitle = `Operation: ${getOperatorLabel()}`;
 
   return (
-    <Card selected={selected} className="min-w-[var(--node-min-width)] p-[var(--card-padding)]">
-      {/* Input ports */}
-      {nodeDefinition?.ports.inputs.map((port, index) => (
-        <Handle
-          key={port.id}
-          type="target"
-          position={Position.Left}
-          id={port.id}
-          className={`h-3 w-3 ${handleClass} !border-2 !border-[var(--text-primary)]`}
-          style={{ top: `${35 + index * 30}%` }}
-        />
-      ))}
-
-      <CardHeader className="p-0 pb-[var(--space-3)]">
-        <div className="flex items-center gap-[var(--space-2)]">
-          <div className="flex h-6 w-6 items-center justify-center rounded bg-[var(--node-logic)] text-[var(--text-primary)]">
-            <Equal size={12} />
-          </div>
-          <span className="font-semibold text-[var(--text-primary)]">
-            {data.identifier.displayName}
-          </span>
-        </div>
-      </CardHeader>
-
-      <CardContent className="space-y-2 p-0">
-        <div className="rounded border border-[var(--border-primary)] bg-[var(--surface-2)] p-2 text-center">
-          <div className="font-mono text-lg text-[var(--text-primary)]">
-            A {getOperatorSymbol()} B
-          </div>
-        </div>
-
-        <div className="flex items-center justify-between">
-          <span className="text-xs text-[var(--text-secondary)]">Operation:</span>
-          <span className="text-xs font-medium text-[var(--text-primary)]">
-            {getOperatorLabel()}
-          </span>
-        </div>
-
-        <div className="text-center text-xs">
-          <span className="rounded-[var(--radius-sm)] bg-[var(--success-100)] px-[var(--space-2)] py-[var(--space-1)] text-[var(--success-700)]">
-            Boolean Output
-          </span>
-        </div>
-
-        <div className="mt-3 border-t border-[var(--border-primary)] pt-2">
-          <div className="text-center text-xs text-[var(--text-tertiary)]">
-            Type-Safe Comparison
-          </div>
-        </div>
-      </CardContent>
-
-      {/* Output port */}
-      {nodeDefinition?.ports.outputs.map((port) => (
-        <Handle
-          key={port.id}
-          type="source"
-          position={Position.Right}
-          id={port.id}
-          className={`h-3 w-3 ${handleClass} !border-2 !border-[var(--text-primary)]`}
-          style={{ top: '50%' }}
-        />
-      ))}
-    </Card>
+    <NodeLayout
+      selected={selected}
+      title={data.identifier.displayName}
+      subtitle={subtitle}
+      icon={<Equal className="h-3 w-3" />}
+      iconBackgroundClass="bg-[var(--node-logic)] text-[var(--text-primary)]"
+      inputs={inputs}
+      outputs={outputs}
+      accentHandleClass="!bg-[var(--node-logic)]"
+    >
+      <div className="rounded border border-[var(--border-primary)] bg-[var(--surface-2)] p-2 text-center">
+        <div className="font-mono text-lg text-[var(--text-primary)]">A {getOperatorSymbol()} B</div>
+      </div>
+      <div className="flex items-center justify-between text-xs">
+        <span>Outputs</span>
+        <span className="font-medium text-[var(--text-primary)]">Boolean</span>
+      </div>
+    </NodeLayout>
   );
 }

--- a/src/components/workspace/nodes/constants-node.tsx
+++ b/src/components/workspace/nodes/constants-node.tsx
@@ -1,15 +1,22 @@
-// src/components/workspace/nodes/constants-node.tsx - Constants value output node
 'use client';
 
-import { Handle, Position, type NodeProps } from 'reactflow';
-import { Card, CardHeader, CardContent } from '@/components/ui/card';
+import type { NodeProps } from 'reactflow';
+
+import { NodeLayout } from './node-layout';
+import { buildPortDisplays } from './port-utils';
 import { getNodeDefinition } from '@/shared/registry/registry-utils';
 import type { ConstantsNodeData } from '@/shared/types/nodes';
 
 export function ConstantsNode({ data, selected }: NodeProps<ConstantsNodeData>) {
   const nodeDefinition = getNodeDefinition('constants');
 
-  // Get current value based on type
+  const outputs = buildPortDisplays(nodeDefinition?.ports.outputs, 'output', {
+    output: {
+      label: 'Constant value',
+      description: 'Provides a reusable constant downstream.',
+    },
+  });
+
   const getCurrentValue = () => {
     switch (data.valueType) {
       case 'number':
@@ -25,16 +32,8 @@ export function ConstantsNode({ data, selected }: NodeProps<ConstantsNodeData>) 
     }
   };
 
-  const getValueDisplay = () => {
-    const value = getCurrentValue();
-    const maxLength = 12;
-    const valueStr = String(value);
-
-    if (valueStr.length > maxLength) {
-      return valueStr.substring(0, maxLength - 3) + '...';
-    }
-    return valueStr;
-  };
+  const value = getCurrentValue();
+  const valueDisplay = String(value).length > 16 ? `${String(value).slice(0, 13)}…` : String(value);
 
   const getTypeIcon = () => {
     switch (data.valueType) {
@@ -51,64 +50,30 @@ export function ConstantsNode({ data, selected }: NodeProps<ConstantsNodeData>) 
     }
   };
 
-  const handleClass = 'bg-[var(--node-data)]';
-
   return (
-    <Card selected={selected} className="min-w-[var(--node-min-width)] p-[var(--card-padding)]">
-      <CardHeader className="p-0 pb-[var(--space-3)]">
-        <div className="flex items-center gap-[var(--space-2)]">
-          <div className="flex h-6 w-6 items-center justify-center rounded bg-[var(--node-data)] text-sm font-bold text-[var(--text-primary)]">
-            {getTypeIcon()}
-          </div>
-          <span className="font-semibold text-[var(--text-primary)]">
-            {data.identifier.displayName}
-          </span>
+    <NodeLayout
+      selected={selected}
+      title={data.identifier.displayName}
+      subtitle={`Type: ${data.valueType}`}
+      icon={<span className="text-xs">{getTypeIcon()}</span>}
+      iconBackgroundClass="bg-[var(--node-data)] text-[var(--text-primary)]"
+      inputs={[]}
+      outputs={outputs}
+      accentHandleClass="!bg-[var(--node-data)]"
+    >
+      <div className="rounded border border-[var(--border-primary)] bg-[var(--surface-2)] p-[var(--space-2)]">
+        <div className="mb-[var(--space-1)] text-xs text-[var(--text-tertiary)]">Current value</div>
+        <div className="font-mono text-sm text-[var(--text-primary)]">{valueDisplay}</div>
+      </div>
+      {data.valueType === 'color' ? (
+        <div className="flex items-center gap-[var(--space-2)] text-xs">
+          <div
+            className="h-4 w-4 rounded border border-[var(--border-primary)]"
+            style={{ backgroundColor: data.colorValue }}
+          />
+          <span className="text-[var(--text-secondary)]">Preview</span>
         </div>
-      </CardHeader>
-
-      <CardContent className="space-y-[var(--space-2)] p-0">
-        <div className="flex items-center justify-between">
-          <span className="text-xs text-[var(--text-secondary)]">Type:</span>
-          <span className="text-xs font-medium text-[var(--text-primary)] capitalize">
-            {data.valueType}
-          </span>
-        </div>
-
-        <div className="rounded border border-[var(--border-primary)] bg-[var(--surface-2)] p-[var(--space-2)]">
-          <div className="mb-[var(--space-1)] text-xs text-[var(--text-tertiary)]">
-            Current Value:
-          </div>
-          <div className="font-mono text-sm text-[var(--text-primary)]">{getValueDisplay()}</div>
-        </div>
-
-        {data.valueType === 'color' && (
-          <div className="flex items-center gap-[var(--space-2)]">
-            <div
-              className="h-4 w-4 rounded border border-[var(--border-primary)]"
-              style={{ backgroundColor: data.colorValue }}
-            />
-            <span className="text-xs text-[var(--text-secondary)]">Preview</span>
-          </div>
-        )}
-
-        <div className="mt-[var(--space-3)] border-t border-[var(--border-primary)] pt-[var(--space-2)]">
-          <div className="text-center text-xs text-[var(--text-tertiary)]">
-            Constant Value Output
-          </div>
-        </div>
-      </CardContent>
-
-      {/* Single output port */}
-      {nodeDefinition?.ports.outputs.map((port) => (
-        <Handle
-          key={port.id}
-          type="source"
-          position={Position.Right}
-          id={port.id}
-          className={`h-3 w-3 ${handleClass} !border-2 !border-[var(--text-primary)]`}
-          style={{ top: `50%` }}
-        />
-      ))}
-    </Card>
+      ) : null}
+    </NodeLayout>
   );
 }

--- a/src/components/workspace/nodes/duplicate-node.tsx
+++ b/src/components/workspace/nodes/duplicate-node.tsx
@@ -1,68 +1,51 @@
 'use client';
 
-import { Handle, Position, type NodeProps } from 'reactflow';
-import { Card, CardHeader, CardContent } from '@/components/ui/card';
+import type { NodeProps } from 'reactflow';
+
+import { NodeLayout } from './node-layout';
+import { buildPortDisplays } from './port-utils';
 import { getNodeDefinition } from '@/shared/registry/registry-utils';
 import type { DuplicateNodeData } from '@/shared/types/nodes';
 import { Copy } from 'lucide-react';
 
 export function DuplicateNode({ data, selected }: NodeProps<DuplicateNodeData>) {
   const nodeDefinition = getNodeDefinition('duplicate');
-  const handleClass = 'bg-[var(--node-logic)]';
+
+  const inputs = buildPortDisplays(nodeDefinition?.ports.inputs, 'input', {
+    input: {
+      label: 'Objects to duplicate',
+      description: 'Supply any object stream to create copies.',
+    },
+  });
+
+  const outputs = buildPortDisplays(nodeDefinition?.ports.outputs, 'output', {
+    output: {
+      label: 'Duplicated objects',
+      description: 'Emits the original and duplicates in order.',
+    },
+  });
+
+  const subtitle = `Copies: ${data.count}`;
 
   return (
-    <Card selected={selected} className="min-w-[var(--node-min-width)] p-[var(--card-padding)]">
-      {/* Input port */}
-      {nodeDefinition?.ports.inputs.map((port) => (
-        <Handle
-          key={port.id}
-          type="target"
-          position={Position.Left}
-          id={port.id}
-          className={`h-3 w-3 ${handleClass} !border-2 !border-[var(--text-primary)]`}
-          style={{ top: `50%` }}
-        />
-      ))}
-
-      <CardHeader className="p-0 pb-[var(--space-3)]">
-        <div className="flex items-center gap-[var(--space-2)]">
-          <div className="flex h-6 w-6 items-center justify-center rounded bg-[var(--node-logic)] text-[var(--text-primary)]">
-            <Copy size={12} />
-          </div>
-          <span className="font-semibold text-[var(--text-primary)]">
-            {data.identifier.displayName}
-          </span>
-        </div>
-      </CardHeader>
-
-      <CardContent className="space-y-2 p-0">
-        <div className="flex items-center justify-between">
-          <span className="text-xs text-[var(--text-secondary)]">Count:</span>
-          <span className="text-xs font-medium text-[var(--text-primary)]">{data.count}</span>
-        </div>
-
-        <div className="text-xs text-[var(--success-500)]">
-          {data.count === 1
-            ? 'Pass-through mode'
-            : `Creating ${data.count - 1} duplicate${data.count > 2 ? 's' : ''}`}
-        </div>
-
-        <div className="text-xs text-[var(--text-tertiary)] italic">
-          Generic duplication - works with any node type
-        </div>
-      </CardContent>
-
-      {/* Output port */}
-      {nodeDefinition?.ports.outputs.map((port) => (
-        <Handle
-          key={port.id}
-          type="source"
-          position={Position.Right}
-          id={port.id}
-          className={`h-3 w-3 ${handleClass} !border-2 !border-[var(--text-primary)]`}
-          style={{ top: `50%` }}
-        />
-      ))}
-    </Card>
+    <NodeLayout
+      selected={selected}
+      title={data.identifier.displayName}
+      subtitle={subtitle}
+      icon={<Copy className="h-3 w-3" />}
+      iconBackgroundClass="bg-[var(--node-logic)] text-[var(--text-primary)]"
+      inputs={inputs}
+      outputs={outputs}
+      accentHandleClass="!bg-[var(--node-logic)]"
+    >
+      <div className="text-xs text-[var(--text-secondary)]">
+        {data.count === 1
+          ? 'Pass-through mode'
+          : `Creates ${data.count - 1} additional duplicate${data.count > 2 ? 's' : ''}.`}
+      </div>
+      <div className="text-xs text-[var(--text-tertiary)] italic">
+        Works with any object type.
+      </div>
+    </NodeLayout>
   );
 }

--- a/src/components/workspace/nodes/filter-node.tsx
+++ b/src/components/workspace/nodes/filter-node.tsx
@@ -1,71 +1,51 @@
-// src/components/workspace/nodes/filter-node.tsx - Confirmed single input/output ports
 'use client';
 
-import { Handle, Position, type NodeProps } from 'reactflow';
-import { Card, CardHeader, CardContent } from '@/components/ui/card';
+import type { NodeProps } from 'reactflow';
+
+import { NodeLayout } from './node-layout';
+import { buildPortDisplays } from './port-utils';
 import { getNodeDefinition } from '@/shared/registry/registry-utils';
 import type { FilterNodeData } from '@/shared/types/nodes';
-import { Filter } from 'lucide-react';
+import { Filter as FilterIcon } from 'lucide-react';
 
 export function FilterNode({ data, selected }: NodeProps<FilterNodeData>) {
   const nodeDefinition = getNodeDefinition('filter');
 
-  const selectedCount = data.selectedObjectIds?.length || 0;
+  const inputs = buildPortDisplays(nodeDefinition?.ports.inputs, 'input', {
+    input: {
+      label: 'Objects to filter',
+      description: 'Provide objects and use the property panel to choose which pass through.',
+    },
+  });
+
+  const outputs = buildPortDisplays(nodeDefinition?.ports.outputs, 'output', {
+    output: {
+      label: 'Filtered objects',
+      description: 'Emits only the objects that match your selection.',
+    },
+  });
+
+  const selectedCount = data.selectedObjectIds?.length ?? 0;
   const hasSelection = selectedCount > 0;
 
-  const handleClass = 'bg-[var(--node-logic)]';
-
   return (
-    <Card selected={selected} className="min-w-[var(--node-min-width)] p-[var(--card-padding)]">
-      {/* Single input port */}
-      {nodeDefinition?.ports.inputs.map((port) => (
-        <Handle
-          key={port.id}
-          type="target"
-          position={Position.Left}
-          id={port.id}
-          className={`h-3 w-3 ${handleClass} !border-2 !border-[var(--text-primary)]`}
-          style={{ top: `50%` }}
-        />
-      ))}
-
-      <CardHeader className="p-0 pb-[var(--space-3)]">
-        <div className="flex items-center gap-[var(--space-2)]">
-          <div className="flex h-6 w-6 items-center justify-center rounded bg-[var(--node-logic)] text-[var(--text-primary)]">
-            <Filter size={12} />
-          </div>
-          <span className="font-semibold text-[var(--text-primary)]">
-            {data.identifier.displayName}
-          </span>
-        </div>
-      </CardHeader>
-
-      <CardContent className="space-y-2 p-0">
-        <div className="flex items-center justify-between">
-          <span className="text-xs text-[var(--text-secondary)]">Selected:</span>
-          <span className="text-xs font-medium text-[var(--text-primary)]">{selectedCount}</span>
-        </div>
-
-        {hasSelection ? (
-          <div className="text-xs text-[var(--success-500)]">
-            {selectedCount} object{selectedCount !== 1 ? 's' : ''} passing through
-          </div>
-        ) : (
-          <div className="text-xs text-[var(--warning-600)]">No objects selected</div>
-        )}
-      </CardContent>
-
-      {/* Single output port */}
-      {nodeDefinition?.ports.outputs.map((port) => (
-        <Handle
-          key={port.id}
-          type="source"
-          position={Position.Right}
-          id={port.id}
-          className={`h-3 w-3 ${handleClass} !border-2 !border-[var(--text-primary)]`}
-          style={{ top: `50%` }}
-        />
-      ))}
-    </Card>
+    <NodeLayout
+      selected={selected}
+      title={data.identifier.displayName}
+      subtitle={hasSelection ? `${selectedCount} object${selectedCount === 1 ? '' : 's'} selected` : 'No objects selected'}
+      icon={<FilterIcon className="h-3 w-3" />}
+      iconBackgroundClass="bg-[var(--node-logic)] text-[var(--text-primary)]"
+      inputs={inputs}
+      outputs={outputs}
+      accentHandleClass="!bg-[var(--node-logic)]"
+    >
+      <div
+        className={`text-xs ${hasSelection ? 'text-[var(--success-500)]' : 'text-[var(--warning-600)]'}`}
+      >
+        {hasSelection
+          ? `${selectedCount} object${selectedCount === 1 ? '' : 's'} passing through`
+          : 'Select objects in the property panel'}
+      </div>
+    </NodeLayout>
   );
 }

--- a/src/components/workspace/nodes/frame-node.tsx
+++ b/src/components/workspace/nodes/frame-node.tsx
@@ -1,14 +1,22 @@
-// src/components/workspace/nodes/frame-node.tsx
 'use client';
 
-import { Handle, Position, type NodeProps } from 'reactflow';
-import { Card, CardHeader, CardContent } from '@/components/ui/card';
+import type { NodeProps } from 'reactflow';
+
+import { NodeLayout } from './node-layout';
+import { buildPortDisplays } from './port-utils';
 import { getNodeDefinition } from '@/shared/registry/registry-utils';
 import type { FrameNodeData } from '@/shared/types/nodes';
 import { Image as ImageIcon } from 'lucide-react';
 
 export function FrameNode({ data, selected }: NodeProps<FrameNodeData>) {
   const nodeDefinition = getNodeDefinition('frame');
+
+  const inputs = buildPortDisplays(nodeDefinition?.ports.inputs, 'input', {
+    input: {
+      label: 'Scene to capture',
+      description: 'Connect the scene or composition that should render as an image.',
+    },
+  });
 
   const getResolutionLabel = (width: number, height: number) => {
     if (width === 1920 && height === 1080) return 'FHD';
@@ -18,74 +26,45 @@ export function FrameNode({ data, selected }: NodeProps<FrameNodeData>) {
     return 'Custom';
   };
 
-  const handleClass = 'bg-[var(--node-output)]';
+  const width = data.width ?? 1920;
+  const height = data.height ?? 1080;
+  const format = data.format ?? 'png';
+  const subtitle = `${width}×${height} • ${getResolutionLabel(width, height)}`;
 
   return (
-    <Card selected={selected} className="min-w-[var(--node-min-width)] p-[var(--card-padding)]">
-      {nodeDefinition?.ports.inputs.map((port) => (
-        <Handle
-          key={port.id}
-          type="target"
-          position={Position.Left}
-          id={port.id}
-          className={`h-3 w-3 ${handleClass} !border-2 !border-[var(--text-primary)]`}
-          style={{ top: `50%` }}
-        />
-      ))}
-
-      <CardHeader className="p-0 pb-[var(--space-3)]">
+    <NodeLayout
+      selected={selected}
+      title={data.identifier.displayName}
+      subtitle={subtitle}
+      icon={<ImageIcon className="h-3 w-3" />}
+      iconBackgroundClass="bg-[var(--node-output)] text-[var(--text-primary)]"
+      inputs={inputs}
+      outputs={[]}
+      accentHandleClass="!bg-[var(--node-output)]"
+      footer="Outputs the final image file"
+    >
+      <div className="flex items-center justify-between text-xs">
+        <span>Background</span>
         <div className="flex items-center gap-[var(--space-2)]">
-          <div className="flex h-6 w-6 items-center justify-center rounded bg-[var(--node-output)] text-[var(--text-primary)]">
-            <ImageIcon size={12} />
-          </div>
-          <div className="min-w-0 flex-1">
-            <div className="truncate font-semibold text-[var(--text-primary)]">
-              {data.identifier.displayName}
-            </div>
-          </div>
-        </div>
-      </CardHeader>
-
-      <CardContent className="space-y-[var(--space-2)] p-0 text-xs text-[var(--text-secondary)]">
-        <div className="flex items-center justify-between">
-          <span>Resolution:</span>
+          <div
+            className="h-4 w-4 rounded border border-[var(--border-primary)]"
+            style={{ backgroundColor: data.backgroundColor || '#000000' }}
+          />
           <span className="font-medium text-[var(--text-primary)]">
-            {getResolutionLabel(data.width || 1920, data.height || 1080)} ({data.width || 1920}×
-            {data.height || 1080})
+            {(data.backgroundColor ?? '#000000').toUpperCase()}
           </span>
         </div>
-
-        <div className="flex items-center justify-between">
-          <span>Background:</span>
-          <div className="flex items-center gap-[var(--space-2)]">
-            <div
-              className="h-4 w-4 rounded border border-[var(--border-primary)]"
-              style={{ backgroundColor: data.backgroundColor || '#000000' }}
-            />
-            <span className="text-xs font-medium text-[var(--text-primary)]">
-              {data.backgroundColor?.toUpperCase() || '#000000'}
-            </span>
-          </div>
+      </div>
+      <div className="flex items-center justify-between text-xs">
+        <span>Format</span>
+        <span className="font-medium uppercase text-[var(--text-primary)]">{format}</span>
+      </div>
+      {format === 'jpeg' ? (
+        <div className="flex items-center justify-between text-xs">
+          <span>Quality</span>
+          <span className="font-medium text-[var(--text-primary)]">{data.quality ?? 90}</span>
         </div>
-
-        <div className="flex items-center justify-between">
-          <span>Format:</span>
-          <span className="font-medium text-[var(--text-primary)] uppercase">
-            {data.format || 'png'}
-          </span>
-        </div>
-
-        {(data.format || 'png') === 'jpeg' && (
-          <div className="flex items-center justify-between">
-            <span>Quality:</span>
-            <span className="font-medium text-[var(--text-primary)]">{data.quality || 90}</span>
-          </div>
-        )}
-
-        <div className="mt-[var(--space-4)] border-t border-[var(--border-primary)] pt-[var(--space-3)] text-center text-xs text-[var(--text-tertiary)]">
-          Final Image Output
-        </div>
-      </CardContent>
-    </Card>
+      ) : null}
+    </NodeLayout>
   );
 }

--- a/src/components/workspace/nodes/if-else-node.tsx
+++ b/src/components/workspace/nodes/if-else-node.tsx
@@ -1,86 +1,57 @@
-// src/components/workspace/nodes/if-else-node.tsx - If/Else logic node
+// src/components/workspace/nodes/if-else-node.tsx - If/Else logic node with structured layout
 'use client';
 
-import { Handle, Position, type NodeProps } from 'reactflow';
-import { Card, CardHeader, CardContent } from '@/components/ui/card';
+import type { NodeProps } from 'reactflow';
 
+import { NodeLayout, type NodePortDisplay } from './node-layout';
 import type { IfElseNodeData } from '@/shared/types/nodes';
 import { GitBranch } from 'lucide-react';
 
 export function IfElseNode({ data, selected }: NodeProps<IfElseNodeData>) {
-  const handleClass = 'bg-[var(--node-logic)]';
+  const inputs: NodePortDisplay[] = [
+    {
+      id: 'condition',
+      label: 'Condition to evaluate',
+      description: 'Boolean input that decides the route.',
+    },
+    {
+      id: 'data',
+      label: 'Data to route',
+      description: 'Payload passed to the true or false path.',
+    },
+  ];
+
+  const outputs: NodePortDisplay[] = [
+    {
+      id: 'true_path',
+      label: 'When condition is true',
+      badge: 'True',
+      badgeTone: 'success',
+      handleClassName: '!bg-[var(--success-500)]',
+    },
+    {
+      id: 'false_path',
+      label: 'When condition is false',
+      badge: 'False',
+      badgeTone: 'danger',
+      handleClassName: '!bg-[var(--danger-500)]',
+    },
+  ];
 
   return (
-    <Card selected={selected} className="min-w-[var(--node-min-width)] p-[var(--card-padding)]">
-      {/* Condition input port */}
-      <Handle
-        type="target"
-        position={Position.Left}
-        id="condition"
-        className={`h-3 w-3 ${handleClass} !border-2 !border-[var(--text-primary)]`}
-        style={{ top: '35%' }}
-      />
-
-      {/* Data input port */}
-      <Handle
-        type="target"
-        position={Position.Left}
-        id="data"
-        className={`h-3 w-3 ${handleClass} !border-2 !border-[var(--text-primary)]`}
-        style={{ top: '65%' }}
-      />
-
-      <CardHeader className="p-0 pb-[var(--space-3)]">
-        <div className="flex items-center gap-[var(--space-2)]">
-          <div className="flex h-6 w-6 items-center justify-center rounded bg-[var(--node-logic)] text-[var(--text-primary)]">
-            <GitBranch size={12} />
-          </div>
-          <span className="font-semibold text-[var(--text-primary)]">
-            {data.identifier.displayName}
-          </span>
-        </div>
-      </CardHeader>
-
-      <CardContent className="space-y-2 p-0">
-        <div className="rounded border border-[var(--border-primary)] bg-[var(--surface-2)] p-2 text-center">
-          <div className="text-sm text-[var(--text-primary)]">
-            if condition → route data to true / else → false
-          </div>
-        </div>
-
-        <div className="grid grid-cols-2 gap-1 text-xs">
-          <div className="text-center text-[var(--success-500)]">True</div>
-          <div className="text-center text-[var(--danger-500)]">False</div>
-        </div>
-
-        <div className="text-center text-xs">
-          <span className="rounded-[var(--radius-sm)] bg-[var(--accent-100)] px-[var(--space-2)] py-[var(--space-1)] text-[var(--accent-900)]">
-            Data Router
-          </span>
-        </div>
-
-        <div className="mt-3 border-t border-[var(--border-primary)] pt-2">
-          <div className="text-center text-xs text-[var(--text-tertiary)]">
-            Condition + Data → Routed Data
-          </div>
-        </div>
-      </CardContent>
-
-      {/* Output ports */}
-      <Handle
-        type="source"
-        position={Position.Right}
-        id="true_path"
-        className={`h-3 w-3 !border-2 !border-[var(--text-primary)] bg-[var(--success-500)]`}
-        style={{ top: '35%' }}
-      />
-      <Handle
-        type="source"
-        position={Position.Right}
-        id="false_path"
-        className={`h-3 w-3 !border-2 !border-[var(--text-primary)] bg-[var(--danger-500)]`}
-        style={{ top: '65%' }}
-      />
-    </Card>
+    <NodeLayout
+      selected={selected}
+      title={data.identifier.displayName}
+      subtitle="Routes data based on a boolean condition"
+      icon={<GitBranch className="h-3 w-3" />}
+      iconBackgroundClass="bg-[var(--node-logic)] text-[var(--text-primary)]"
+      inputs={inputs}
+      outputs={outputs}
+      accentHandleClass="!bg-[var(--node-logic)]"
+    >
+      <div className="rounded border border-[var(--border-primary)] bg-[var(--surface-2)] p-2 text-center text-xs text-[var(--text-secondary)]">
+        Condition → True path, else → False path
+      </div>
+    </NodeLayout>
   );
 }

--- a/src/components/workspace/nodes/image-node.tsx
+++ b/src/components/workspace/nodes/image-node.tsx
@@ -1,41 +1,37 @@
 'use client';
 
-import { Handle, Position, type NodeProps } from 'reactflow';
-import { Card, CardHeader, CardContent } from '@/components/ui/card';
+import type { NodeProps } from 'reactflow';
+
+import { NodeLayout } from './node-layout';
+import { buildPortDisplays } from './port-utils';
 import { getNodeDefinition } from '@/shared/registry/registry-utils';
 import type { ImageNodeData } from '@/shared/types/nodes';
-import { Image } from 'lucide-react';
+import { Image as ImageIcon } from 'lucide-react';
 
 export function ImageNode({ data, selected }: NodeProps<ImageNodeData>) {
   const nodeDefinition = getNodeDefinition('image');
+  const outputs = buildPortDisplays(nodeDefinition?.ports.outputs, 'output', {
+    output: {
+      label: 'Image asset for scenes',
+      description: 'Passes the selected still image to media or canvas nodes.',
+    },
+  });
 
   return (
-    <Card selected={selected} className="min-w-[var(--node-min-width)] p-[var(--card-padding)]">
-      <CardHeader className="p-0 pb-[var(--space-3)]">
-        <div className="flex items-center gap-[var(--space-2)]">
-          <div className="flex h-6 w-6 items-center justify-center rounded bg-[var(--node-input)] text-[var(--text-primary)]">
-            <Image size={12} aria-label="Image node icon" />
-          </div>
-          <span className="font-semibold text-[var(--text-primary)]">
-            {data.identifier.displayName}
-          </span>
-        </div>
-      </CardHeader>
-
-      <CardContent className="space-y-1 p-0 text-xs text-[var(--text-secondary)]">
-        <div className="text-[var(--text-tertiary)]">Connect to Media node for editing</div>
-      </CardContent>
-
-      {nodeDefinition?.ports.outputs.map((port) => (
-        <Handle
-          key={port.id}
-          type="source"
-          position={Position.Right}
-          id={port.id}
-          className="h-3 w-3 !border-2 !border-[var(--text-primary)] bg-[var(--node-input)]"
-          style={{ top: '50%' }}
-        />
-      ))}
-    </Card>
+    <NodeLayout
+      selected={selected}
+      title={data.identifier.displayName}
+      subtitle="Starter image asset"
+      icon={<ImageIcon className="h-3 w-3" />}
+      iconBackgroundClass="bg-[var(--node-input)] text-[var(--text-primary)]"
+      inputs={[]}
+      outputs={outputs}
+      accentHandleClass="!bg-[var(--node-input)]"
+      footer="Connect to a Media node to choose and crop the image"
+    >
+      <div className="text-xs text-[var(--text-secondary)]">
+        Placeholder asset until a media item is selected.
+      </div>
+    </NodeLayout>
   );
 }

--- a/src/components/workspace/nodes/math-op-node.tsx
+++ b/src/components/workspace/nodes/math-op-node.tsx
@@ -1,8 +1,10 @@
-// src/components/workspace/nodes/math-op-node.tsx - Math operation logic node
+// src/components/workspace/nodes/math-op-node.tsx - Math operation node with structured layout
 'use client';
 
-import { Handle, Position, type NodeProps } from 'reactflow';
-import { Card, CardHeader, CardContent } from '@/components/ui/card';
+import type { NodeProps } from 'reactflow';
+
+import { NodeLayout, type NodePortDisplay } from './node-layout';
+import { buildPortDisplays } from './port-utils';
 import { getNodeDefinitionWithDynamicPorts } from '@/shared/registry/registry-utils';
 import type { MathOpNodeData } from '@/shared/types/nodes';
 import { Calculator } from 'lucide-react';
@@ -13,126 +15,76 @@ export function MathOpNode({ data, selected }: NodeProps<MathOpNodeData>) {
     data as unknown as Record<string, unknown>
   );
 
-  const getOperatorDisplay = () => {
-    switch (data.operator) {
-      case 'add':
-        return 'ADD';
-      case 'subtract':
-        return 'SUB';
-      case 'multiply':
-        return 'MUL';
-      case 'divide':
-        return 'DIV';
-      case 'modulo':
-        return 'MOD';
-      case 'power':
-        return 'POW';
-      case 'sqrt':
-        return 'SQRT';
-      case 'abs':
-        return 'ABS';
-      case 'min':
-        return 'MIN';
-      case 'max':
-        return 'MAX';
-    }
+  const OPERATOR_DISPLAY: Record<MathOpNodeData['operator'], string> = {
+    add: 'ADD',
+    subtract: 'SUBTRACT',
+    multiply: 'MULTIPLY',
+    divide: 'DIVIDE',
+    modulo: 'MODULO',
+    power: 'POWER',
+    sqrt: 'SQUARE ROOT',
+    abs: 'ABSOLUTE',
+    min: 'MIN',
+    max: 'MAX',
   };
 
-  const getOperatorSymbol = () => {
-    switch (data.operator) {
-      case 'add':
-        return '+';
-      case 'subtract':
-        return '-';
-      case 'multiply':
-        return '×';
-      case 'divide':
-        return '÷';
-      case 'modulo':
-        return '%';
-      case 'power':
-        return '^';
-      case 'sqrt':
-        return '√A';
-      case 'abs':
-        return '|A|';
-      case 'min':
-        return 'min';
-      case 'max':
-        return 'max';
-    }
+  const OPERATOR_SYMBOL: Record<MathOpNodeData['operator'], string> = {
+    add: '+',
+    subtract: '-',
+    multiply: '×',
+    divide: '÷',
+    modulo: '%',
+    power: '^',
+    sqrt: '√',
+    abs: '|A|',
+    min: 'min',
+    max: 'max',
   };
 
-  const isUnaryOperation = () => data.operator === 'sqrt' || data.operator === 'abs';
+  const getOperatorDisplay = () => OPERATOR_DISPLAY[data.operator];
 
-  const handleClass = 'bg-[var(--node-logic)]';
+  const getOperatorExpression = () => {
+    if (data.operator === 'abs') {
+      return OPERATOR_SYMBOL[data.operator];
+    }
+    if (data.operator === 'sqrt') {
+      return `${OPERATOR_SYMBOL[data.operator]}A`;
+    }
+    return `A ${OPERATOR_SYMBOL[data.operator]} B`;
+  };
+
+  const isUnaryOperation = data.operator === 'sqrt' || data.operator === 'abs';
+
+  const inputs: NodePortDisplay[] = (nodeDefinition?.ports.inputs ?? []).map((port, index) => ({
+    id: port.id,
+    label: isUnaryOperation ? 'Value' : index === 0 ? 'Value A' : 'Value B',
+    description: 'Provide the numeric values for this operation.',
+  }));
+
+  const outputs = buildPortDisplays(nodeDefinition?.ports.outputs, 'output', {
+    output: {
+      label: 'Computed value',
+      description: 'Outputs the numeric result of the operation.',
+    },
+  });
+
+  const subtitle = `Operation: ${getOperatorDisplay()}`;
 
   return (
-    <Card selected={selected} className="min-w-[var(--node-min-width)] p-[var(--card-padding)]">
-      {/* Dynamic input ports */}
-      {nodeDefinition?.ports.inputs.map((port, index) => (
-        <Handle
-          key={port.id}
-          type="target"
-          position={Position.Left}
-          id={port.id}
-          className={`h-3 w-3 ${handleClass} !border-2 !border-[var(--text-primary)]`}
-          style={{ top: `${35 + index * 30}%` }}
-        />
-      ))}
-
-      <CardHeader className="p-0 pb-[var(--space-3)]">
-        <div className="flex items-center gap-[var(--space-2)]">
-          <div className="flex h-6 w-6 items-center justify-center rounded bg-[var(--node-logic)] text-[var(--text-primary)]">
-            <Calculator size={12} />
-          </div>
-          <span className="font-semibold text-[var(--text-primary)]">
-            {data.identifier.displayName}
-          </span>
-        </div>
-      </CardHeader>
-
-      <CardContent className="space-y-2 p-0">
-        <div className="rounded border border-[var(--border-primary)] bg-[var(--surface-2)] p-2 text-center">
-          <div className="font-mono text-sm text-[var(--text-primary)]">
-            Math ({getOperatorDisplay()})
-          </div>
-          <div className="mt-1 font-mono text-lg text-[var(--text-primary)]">
-            {isUnaryOperation() ? getOperatorSymbol() : `A ${getOperatorSymbol()} B`}
-          </div>
-        </div>
-
-        <div className="flex items-center justify-between">
-          <span className="text-xs text-[var(--text-secondary)]">Operation:</span>
-          <span className="text-xs font-medium text-[var(--text-primary)]">
-            {getOperatorDisplay()}
-          </span>
-        </div>
-
-        <div className="text-center text-xs">
-          <span className="rounded-[var(--radius-sm)] bg-[var(--accent-100)] px-[var(--space-2)] py-[var(--space-1)] text-[var(--accent-900)]">
-            Number Math
-          </span>
-        </div>
-
-        <div className="mt-3 border-t border-[var(--border-primary)] pt-2">
-          <div className="text-center text-xs text-[var(--text-tertiary)]">
-            {isUnaryOperation() ? '1 Input' : '2 Inputs'} → Number
-          </div>
-        </div>
-      </CardContent>
-
-      {/* Output port */}
-      {nodeDefinition?.ports.outputs.map((port) => (
-        <Handle
-          key={port.id}
-          type="source"
-          position={Position.Right}
-          id={port.id}
-          className={`h-3 w-3 ${handleClass} !border-2 !border-[var(--text-primary)]`}
-          style={{ top: '50%' }}
-        />
-      ))}
-    </Card>
+    <NodeLayout
+      selected={selected}
+      title={data.identifier.displayName}
+      subtitle={subtitle}
+      icon={<Calculator className="h-3 w-3" />}
+      iconBackgroundClass="bg-[var(--node-logic)] text-[var(--text-primary)]"
+      inputs={inputs}
+      outputs={outputs}
+      accentHandleClass="!bg-[var(--node-logic)]"
+    >
+      <div className="rounded border border-[var(--border-primary)] bg-[var(--surface-2)] p-2 text-center">
+        <div className="font-mono text-sm text-[var(--text-primary)]">Math ({getOperatorDisplay()})</div>
+        <div className="mt-1 font-mono text-lg text-[var(--text-primary)]">{getOperatorExpression()}</div>
+      </div>
+    </NodeLayout>
   );
 }

--- a/src/components/workspace/nodes/media-node.tsx
+++ b/src/components/workspace/nodes/media-node.tsx
@@ -1,10 +1,12 @@
 'use client';
 
-import { Handle, Position, type NodeProps } from 'reactflow';
-import { Card, CardHeader, CardContent } from '@/components/ui/card';
+import type { NodeProps } from 'reactflow';
+
+import { NodeLayout } from './node-layout';
+import { buildPortDisplays } from './port-utils';
 import { getNodeDefinition } from '@/shared/registry/registry-utils';
 import type { MediaNodeData } from '@/shared/types/nodes';
-import { Image, Settings } from 'lucide-react';
+import { Image as ImageIcon, Settings } from 'lucide-react';
 
 export function MediaNode({
   data,
@@ -13,11 +15,27 @@ export function MediaNode({
 }: NodeProps<MediaNodeData> & { onOpenMedia?: () => void }) {
   const nodeDefinition = getNodeDefinition('media');
 
+  const inputs = buildPortDisplays(nodeDefinition?.ports.inputs, 'input', {
+    input: {
+      label: 'Image objects to refine',
+      description: 'Connect upstream image objects before applying media adjustments.',
+    },
+  });
+
+  const outputs = buildPortDisplays(nodeDefinition?.ports.outputs, 'output', {
+    output: {
+      label: 'Media-adjusted image objects',
+      description: 'Delivers cropped and sized images to the rest of your scene.',
+    },
+  });
+
   const handleDoubleClick = () => {
     if (onOpenMedia) {
       onOpenMedia();
-    } else {
-      // Dispatch custom event to open media editor
+      return;
+    }
+
+    if (typeof window !== 'undefined') {
       window.dispatchEvent(
         new CustomEvent('open-media-editor', {
           detail: { nodeId: data.identifier.id },
@@ -26,61 +44,43 @@ export function MediaNode({
     }
   };
 
-  const currentAsset = data.imageAssetId ? 'Selected' : 'No asset';
-  const cropInfo = data.cropWidth > 0 ? `${data.cropWidth}×${data.cropHeight}` : 'Full size';
+  const assetStatus = data.imageAssetId ? 'Asset selected' : 'No asset';
+  const cropInfo =
+    data.cropWidth > 0 && data.cropHeight > 0
+      ? `${data.cropWidth}×${data.cropHeight}`
+      : 'Full frame';
+  const displayInfo =
+    data.displayWidth > 0 && data.displayHeight > 0
+      ? `${data.displayWidth}×${data.displayHeight}`
+      : 'Auto fit';
 
   return (
-    <Card
+    <NodeLayout
       selected={selected}
-      className="min-w-[var(--node-min-width)] cursor-pointer p-[var(--card-padding)] transition-all hover:bg-[var(--surface-interactive)]"
+      className="cursor-pointer transition-colors hover:bg-[var(--surface-interactive)]"
+      title={data.identifier.displayName}
+      subtitle={data.imageAssetId ? 'Asset linked from library' : 'No asset linked yet'}
+      icon={<ImageIcon className="h-3 w-3" />}
+      iconBackgroundClass="bg-[var(--node-animation)] text-[var(--text-primary)]"
+      headerAside={<Settings className="h-3 w-3 text-[var(--text-tertiary)]" />}
+      inputs={inputs}
+      outputs={outputs}
+      accentHandleClass="!bg-[var(--node-animation)]"
       onDoubleClick={handleDoubleClick}
+      footer="Double-click to open the Media editor"
     >
-      <CardHeader className="p-0 pb-[var(--space-3)]">
-        <div className="flex items-center gap-[var(--space-2)]">
-          <div className="flex h-6 w-6 items-center justify-center rounded bg-[var(--node-animation)] text-[var(--text-primary)]">
-            <Image size={12} aria-label="Media node icon" />
-          </div>
-          <div className="min-w-0 flex-1">
-            <div className="truncate font-semibold text-[var(--text-primary)]">
-              {data.identifier.displayName}
-            </div>
-          </div>
-          <Settings size={12} className="text-[var(--text-tertiary)]" />
-        </div>
-      </CardHeader>
-
-      <CardContent className="space-y-1 p-0 text-xs text-[var(--text-secondary)]">
-        <div className="truncate">Asset: {currentAsset}</div>
-        <div>Crop: {cropInfo}</div>
-        <div>
-          Display: {data.displayWidth > 0 ? `${data.displayWidth}×${data.displayHeight}` : 'Auto'}
-        </div>
-        <div className="pt-1 text-[10px] text-[var(--text-tertiary)]">
-          Double-click to edit in Media tab
-        </div>
-      </CardContent>
-
-      {nodeDefinition?.ports.inputs.map((port) => (
-        <Handle
-          key={port.id}
-          type="target"
-          position={Position.Left}
-          id={port.id}
-          className="h-3 w-3 !border-2 !border-[var(--text-primary)] bg-[var(--node-animation)]"
-          style={{ top: '50%' }}
-        />
-      ))}
-
-      {nodeDefinition?.ports.outputs.map((port) => (
-        <Handle
-          key={port.id}
-          type="source"
-          position={Position.Right}
-          id={port.id}
-          className="h-3 w-3 !border-2 !border-[var(--text-primary)] bg-[var(--node-animation)]"
-          style={{ top: '50%' }}
-        />
-      ))}
-    </Card>
+      <div className="flex items-center justify-between text-xs">
+        <span>Asset</span>
+        <span className="font-medium text-[var(--text-primary)]">{assetStatus}</span>
+      </div>
+      <div className="flex items-center justify-between text-xs">
+        <span>Crop</span>
+        <span className="font-medium text-[var(--text-primary)]">{cropInfo}</span>
+      </div>
+      <div className="flex items-center justify-between text-xs">
+        <span>Display</span>
+        <span className="font-medium text-[var(--text-primary)]">{displayInfo}</span>
+      </div>
+    </NodeLayout>
   );
 }

--- a/src/components/workspace/nodes/merge-node.tsx
+++ b/src/components/workspace/nodes/merge-node.tsx
@@ -1,93 +1,50 @@
 'use client';
 
-import { Handle, Position, type NodeProps } from 'reactflow';
-import { Card, CardHeader, CardContent } from '@/components/ui/card';
+import type { NodeProps } from 'reactflow';
 
+import { NodeLayout, type NodePortDisplay } from './node-layout';
+import { buildPortDisplays } from './port-utils';
 import type { MergeNodeData } from '@/shared/types/nodes';
+import { getNodeDefinitionWithDynamicPorts } from '@/shared/registry/registry-utils';
 
 export function MergeNode({ data, selected }: NodeProps<MergeNodeData>) {
-  const portCount = data.inputPortCount || 2;
+  const nodeDefinition = getNodeDefinitionWithDynamicPorts(
+    'merge',
+    data as unknown as Record<string, unknown>
+  );
 
-  // Generate dynamic input ports
-  const inputPorts = Array.from({ length: portCount }, (_, i) => ({
-    id: `input${i + 1}`,
-    label: i === 0 ? 'Input 1 (Priority)' : `Input ${i + 1}`,
+  const inputPorts: NodePortDisplay[] = (nodeDefinition?.ports.inputs ?? []).map((port, index) => ({
+    id: port.id,
+    label: index === 0 ? 'Source 1 (priority)' : `Source ${index + 1}`,
+    description:
+      index === 0
+        ? 'Primary stream when conflicts occur.'
+        : 'Merged stream following the primary source.',
   }));
 
-  // Calculate port spacing to avoid overlap
-  const getPortTopPosition = (index: number) => {
-    if (portCount <= 2) {
-      return index === 0 ? '30%' : '70%';
-    } else if (portCount === 3) {
-      return ['25%', '50%', '75%'][index];
-    } else if (portCount === 4) {
-      return ['20%', '40%', '60%', '80%'][index];
-    } else {
-      // 5 ports
-      return ['15%', '30%', '50%', '70%', '85%'][index];
-    }
-  };
+  const outputs = buildPortDisplays(nodeDefinition?.ports.outputs, 'output', {
+    output: {
+      label: 'Merged objects',
+      description: 'Combined stream preserving priority order.',
+    },
+  });
 
-  // Dynamic height based on port count for better port spacing
-  const getNodeHeight = () => {
-    if (portCount <= 2) return 'min-h-[120px]';
-    if (portCount === 3) return 'min-h-[140px]';
-    if (portCount === 4) return 'min-h-[160px]';
-    return 'min-h-[180px]'; // 5 ports
-  };
-
-  const handleClass = 'bg-[var(--node-logic)]';
+  const portCount = inputPorts.length;
 
   return (
-    <Card
-      className={`min-w-[var(--node-min-width)] p-[var(--card-padding)] ${getNodeHeight()} ${selected ? 'ring-2 ring-[var(--accent-primary)]' : ''}`}
+    <NodeLayout
+      selected={selected}
+      title={data.identifier.displayName}
+      subtitle={`${portCount} source${portCount === 1 ? '' : 's'}`}
+      icon={<span className="text-xs">⊕</span>}
+      iconBackgroundClass="bg-[var(--node-logic)] text-[var(--text-primary)]"
+      inputs={inputPorts}
+      outputs={outputs}
+      accentHandleClass="!bg-[var(--node-logic)]"
     >
-      {/* Dynamic input ports */}
-      {inputPorts.map((port, index) => (
-        <Handle
-          key={port.id}
-          type="target"
-          position={Position.Left}
-          id={port.id}
-          className={`h-3 w-3 ${handleClass} !border-2 !border-[var(--text-primary)]`}
-          style={{ top: getPortTopPosition(index) }}
-        />
-      ))}
-
-      <CardHeader className="p-0 pb-[var(--space-3)]">
-        <div className="flex items-center gap-[var(--space-2)]">
-          <div className="flex h-6 w-6 items-center justify-center rounded bg-[var(--node-logic)] text-sm font-bold text-[var(--text-primary)]">
-            ⊕
-          </div>
-          <span className="font-semibold text-[var(--text-primary)]">
-            {data.identifier.displayName}
-          </span>
-        </div>
-      </CardHeader>
-
-      <CardContent className="space-y-2 p-0">
-        <div className="flex items-center justify-between">
-          <span className="text-xs text-[var(--text-secondary)]">Ports:</span>
-          <span className="text-xs font-medium text-[var(--text-primary)]">{portCount}</span>
-        </div>
-
-        <div className="text-xs text-[var(--accent-primary)]">Port 1 has merge priority</div>
-
-        <div className="mt-3 border-t border-[var(--border-primary)] pt-2">
-          <div className="text-center text-xs text-[var(--text-tertiary)]">
-            Resolves object ID conflicts
-          </div>
-        </div>
-      </CardContent>
-
-      {/* Single output port */}
-      <Handle
-        type="source"
-        position={Position.Right}
-        id="output"
-        className={`h-3 w-3 ${handleClass} !border-2 !border-[var(--text-primary)]`}
-        style={{ top: '50%' }}
-      />
-    </Card>
+      <div className="text-xs text-[var(--text-secondary)]">
+        Source 1 wins when IDs conflict. Additional sources cascade after.
+      </div>
+    </NodeLayout>
   );
 }

--- a/src/components/workspace/nodes/node-layout.tsx
+++ b/src/components/workspace/nodes/node-layout.tsx
@@ -1,0 +1,447 @@
+'use client';
+
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+} from 'react';
+import { Handle, Position } from 'reactflow';
+
+import { Card } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+
+const PORT_ZONE_GAP = 12;
+const MIN_ZONE_WIDTH = 48;
+const MAX_ZONE_WIDTH = 176;
+
+export type NodePortBadgeTone =
+  | 'neutral'
+  | 'accent'
+  | 'success'
+  | 'danger'
+  | 'warning'
+  | 'info';
+
+const BADGE_TONE_CLASSES: Record<NodePortBadgeTone, string> = {
+  neutral:
+    'bg-[var(--surface-2)]/80 text-[var(--text-secondary)] border border-[var(--border-primary)]',
+  accent: 'bg-[var(--accent-primary)] text-white',
+  success: 'bg-[var(--success-500)] text-white',
+  danger: 'bg-[var(--danger-500)] text-white',
+  warning: 'bg-[var(--warning-500)] text-[var(--surface-0)]',
+  info: 'bg-[var(--accent-secondary)] text-white',
+};
+
+export interface NodePortDisplay {
+  id: string;
+  label: string;
+  description?: string;
+  badge?: string;
+  badgeTone?: NodePortBadgeTone;
+  icon?: React.ReactNode;
+  handleClassName?: string;
+}
+
+export interface NodeLayoutProps {
+  title: string;
+  subtitle?: string;
+  titleTooltip?: string;
+  icon?: React.ReactNode;
+  iconBackgroundClass?: string;
+  iconForegroundClass?: string;
+  tag?: string;
+  tagTone?: NodePortBadgeTone;
+  headerAside?: React.ReactNode;
+  inputs: NodePortDisplay[];
+  outputs: NodePortDisplay[];
+  selected?: boolean;
+  className?: string;
+  children?: React.ReactNode;
+  footer?: React.ReactNode;
+  accentHandleClass?: string;
+  onClick?: React.MouseEventHandler<HTMLDivElement>;
+  onDoubleClick?: React.MouseEventHandler<HTMLDivElement>;
+}
+
+interface LayoutMetrics {
+  leftZone: number;
+  rightZone: number;
+  inputTops: number[];
+  outputTops: number[];
+}
+
+const INITIAL_METRICS: LayoutMetrics = {
+  leftZone: 0,
+  rightZone: 0,
+  inputTops: [],
+  outputTops: [],
+};
+
+const deriveHandleClass = (token?: string) => {
+  if (!token) return undefined;
+  return token
+    .split(' ')
+    .filter(Boolean)
+    .map((part) =>
+      part.startsWith('bg-') || part.startsWith('bg[') ? `!${part}` : part
+    )
+    .join(' ');
+};
+
+const nearlyEqual = (a: number, b: number) => Math.abs(a - b) < 0.5;
+
+const arraysEqual = (a: number[], b: number[]) => {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i += 1) {
+    if (!nearlyEqual(a[i] ?? 0, b[i] ?? 0)) return false;
+  }
+  return true;
+};
+
+function ensureRefLength(ref: React.MutableRefObject<(HTMLDivElement | null)[]>, length: number) {
+  if (ref.current.length === length) return;
+  const next: (HTMLDivElement | null)[] = [];
+  for (let i = 0; i < length; i += 1) {
+    next.push(ref.current[i] ?? null);
+  }
+  ref.current = next;
+}
+
+export function NodeLayout({
+  title,
+  subtitle,
+  titleTooltip,
+  icon,
+  iconBackgroundClass,
+  iconForegroundClass,
+  tag,
+  tagTone = 'neutral',
+  headerAside,
+  inputs,
+  outputs,
+  selected,
+  className,
+  children,
+  footer,
+  accentHandleClass,
+  onClick,
+    onDoubleClick,
+  }: NodeLayoutProps) {
+  const cardRef = useRef<HTMLDivElement>(null);
+  const inputLabelRefs = useRef<(HTMLDivElement | null)[]>([]);
+  const outputLabelRefs = useRef<(HTMLDivElement | null)[]>([]);
+  const [metrics, setMetrics] = useState<LayoutMetrics>(INITIAL_METRICS);
+
+  ensureRefLength(inputLabelRefs, inputs.length);
+  ensureRefLength(outputLabelRefs, outputs.length);
+
+  const setInputRef = useCallback(
+    (index: number) => (node: HTMLDivElement | null) => {
+      inputLabelRefs.current[index] = node;
+    },
+    []
+  );
+
+  const setOutputRef = useCallback(
+    (index: number) => (node: HTMLDivElement | null) => {
+      outputLabelRefs.current[index] = node;
+    },
+    []
+  );
+
+  const defaultHandleClass = useMemo(() => {
+    if (accentHandleClass) return accentHandleClass;
+    return deriveHandleClass(iconBackgroundClass) ?? '!bg-[var(--accent-primary)]';
+  }, [accentHandleClass, iconBackgroundClass]);
+
+  const measureLayout = useCallback(() => {
+    const card = cardRef.current;
+    if (!card) return;
+
+    const cardRect = card.getBoundingClientRect();
+
+    const computeZoneWidth = (refs: (HTMLDivElement | null)[]) => {
+      if (!refs.length) return 0;
+      const widths = refs.map((ref) => ref?.getBoundingClientRect().width ?? 0);
+      const measured = Math.max(...widths, 0);
+      const minimum = widths.length > 0 ? MIN_ZONE_WIDTH : 0;
+      const desired = Math.max(measured, minimum);
+      return Math.min(desired, MAX_ZONE_WIDTH);
+    };
+
+    const computeCenters = (refs: (HTMLDivElement | null)[]) => {
+      if (!refs.length) return [] as number[];
+      return refs.map((ref, index) => {
+        if (!ref) {
+          return ((index + 1) / (refs.length + 1)) * cardRect.height;
+        }
+        const rect = ref.getBoundingClientRect();
+        return rect.top - cardRect.top + rect.height / 2;
+      });
+    };
+
+    const leftZone = computeZoneWidth(inputLabelRefs.current);
+    const rightZone = computeZoneWidth(outputLabelRefs.current);
+    const inputCenters = computeCenters(inputLabelRefs.current);
+    const outputCenters = computeCenters(outputLabelRefs.current);
+
+    setMetrics((previous) => {
+      if (
+        nearlyEqual(previous.leftZone, leftZone) &&
+        nearlyEqual(previous.rightZone, rightZone) &&
+        arraysEqual(previous.inputTops, inputCenters) &&
+        arraysEqual(previous.outputTops, outputCenters)
+      ) {
+        return previous;
+      }
+
+      return {
+        leftZone,
+        rightZone,
+        inputTops: inputCenters,
+        outputTops: outputCenters,
+      };
+    });
+  }, []);
+
+  const portsSignature = useMemo(() => {
+    const serialize = (port: NodePortDisplay) =>
+      [port.id, port.label, port.badge ?? '', port.badgeTone ?? '', port.icon ? '1' : '0'].join('::');
+    const inputSignature = inputs.map(serialize).join('||');
+    const outputSignature = outputs.map(serialize).join('||');
+    return `${inputSignature}__${outputSignature}`;
+  }, [inputs, outputs]);
+
+  useLayoutEffect(() => {
+    measureLayout();
+  }, [measureLayout]);
+
+  useEffect(() => {
+    measureLayout();
+  }, [measureLayout, portsSignature]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    if (typeof ResizeObserver === 'undefined') {
+      const handleResize = () => {
+        measureLayout();
+      };
+      window.addEventListener('resize', handleResize);
+      return () => {
+        window.removeEventListener('resize', handleResize);
+      };
+    }
+
+    const card = cardRef.current;
+    if (!card) return;
+
+    let frame = 0;
+    const observer = new ResizeObserver(() => {
+      if (frame) window.cancelAnimationFrame(frame);
+      frame = window.requestAnimationFrame(() => {
+        frame = 0;
+        measureLayout();
+      });
+    });
+
+    observer.observe(card);
+
+    return () => {
+      if (frame) window.cancelAnimationFrame(frame);
+      observer.disconnect();
+    };
+  }, [measureLayout]);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (typeof document !== 'undefined' && 'fonts' in document) {
+      void document.fonts.ready.then(() => {
+        if (!cancelled) {
+          measureLayout();
+        }
+      });
+    }
+    return () => {
+      cancelled = true;
+    };
+  }, [measureLayout]);
+
+  const leftPadding = metrics.leftZone > 0 ? metrics.leftZone + PORT_ZONE_GAP : 0;
+  const rightPadding = metrics.rightZone > 0 ? metrics.rightZone + PORT_ZONE_GAP : 0;
+
+  const centerStyle: CSSProperties = {
+    paddingTop: 'var(--card-padding)',
+    paddingBottom: 'var(--card-padding)',
+    paddingLeft: `calc(var(--card-padding) + ${leftPadding}px)`,
+    paddingRight: `calc(var(--card-padding) + ${rightPadding}px)`,
+  };
+
+  const leftZoneStyle: CSSProperties = {
+    top: 'var(--card-padding)',
+    bottom: 'var(--card-padding)',
+    left: 'var(--card-padding)',
+    width: metrics.leftZone > 0 ? `${metrics.leftZone}px` : undefined,
+  };
+
+  const rightZoneStyle: CSSProperties = {
+    top: 'var(--card-padding)',
+    bottom: 'var(--card-padding)',
+    right: 'var(--card-padding)',
+    width: metrics.rightZone > 0 ? `${metrics.rightZone}px` : undefined,
+  };
+
+  const renderPortRow = (
+    port: NodePortDisplay,
+    index: number,
+    side: 'input' | 'output',
+    refSetter: (node: HTMLDivElement | null) => void
+  ) => {
+    const badgeTone = port.badgeTone ?? (side === 'input' ? 'neutral' : 'accent');
+    const badge = port.badge ?? (side === 'input' ? 'In' : 'Out');
+    const topPositions = side === 'input' ? metrics.inputTops : metrics.outputTops;
+    const topValue = topPositions[index];
+
+    return (
+      <div
+        key={port.id}
+        ref={refSetter}
+        className={cn(
+          'node-port-row relative flex items-center gap-[var(--space-2)] rounded-[var(--radius-sm)] border border-transparent px-[var(--space-2)] py-[var(--space-1)] text-xs transition-colors duration-[var(--duration-fast)] ease-[var(--easing-standard)] hover:border-[var(--border-primary)] hover:bg-[var(--surface-interactive)]/60',
+          side === 'output' ? 'flex-row-reverse text-right' : 'text-left'
+        )}
+        style={{ maxWidth: `${MAX_ZONE_WIDTH}px` }}
+        title={port.description ?? port.label}
+      >
+        <span
+          className={cn(
+            'inline-flex min-w-[2.5rem] items-center justify-center rounded-full px-[var(--space-2)] py-[var(--space-half)] text-[10px] font-semibold uppercase tracking-wide',
+            BADGE_TONE_CLASSES[badgeTone]
+          )}
+        >
+          {badge}
+        </span>
+        <span
+          className={cn(
+            'node-port-label flex min-w-0 items-start gap-[var(--space-1)] text-[var(--text-secondary)]',
+            side === 'output' ? 'justify-end text-right' : 'justify-start'
+          )}
+        >
+          {port.icon ? <span className="shrink-0 text-[var(--text-secondary)]">{port.icon}</span> : null}
+          <span className="node-port-label-text leading-[1.2]">{port.label}</span>
+        </span>
+        <Handle
+          type={side === 'input' ? 'target' : 'source'}
+          position={side === 'input' ? Position.Left : Position.Right}
+          id={port.id}
+          className={cn(
+            'node-port-handle h-3 w-3 !border-2 !border-[var(--text-primary)]',
+            defaultHandleClass,
+            port.handleClassName
+          )}
+          style={{
+            top:
+              typeof topValue === 'number'
+                ? `${topValue}px`
+                : `${((index + 1) / ((side === 'input' ? inputs : outputs).length + 1)) * 100}%`,
+          }}
+        />
+      </div>
+    );
+  };
+
+  return (
+    <Card
+      ref={cardRef}
+      selected={selected}
+      className={cn('relative min-w-[var(--node-min-width)] overflow-visible', className)}
+      onClick={onClick}
+      onDoubleClick={onDoubleClick}
+    >
+      <div className="node-center-zone" style={centerStyle}>
+        <div className="flex items-start justify-between gap-[var(--space-2)]">
+          <div className="flex min-w-0 flex-1 items-start gap-[var(--space-2)]">
+            {icon ? (
+              <div
+                className={cn(
+                  'flex h-7 w-7 shrink-0 items-center justify-center rounded-[var(--radius-sm)]',
+                  iconBackgroundClass ?? 'bg-[var(--accent-primary)]/20'
+                )}
+              >
+                <div className={cn('text-[var(--text-primary)]', iconForegroundClass)}>{icon}</div>
+              </div>
+            ) : null}
+            <div className="min-w-0 flex-1 space-y-[var(--space-half)]">
+              <div className="flex items-center gap-[var(--space-1)]">
+                <span
+                  className="truncate text-sm font-semibold text-[var(--text-primary)]"
+                  title={titleTooltip ?? title}
+                >
+                  {title}
+                </span>
+                {tag ? (
+                  <span
+                    className={cn(
+                      'node-header-tag inline-flex items-center rounded-full px-[var(--space-2)] py-[var(--space-half)] text-[10px] font-semibold uppercase tracking-wide',
+                      BADGE_TONE_CLASSES[tagTone]
+                    )}
+                  >
+                    {tag}
+                  </span>
+                ) : null}
+              </div>
+              {subtitle ? (
+                <div className="node-subtitle text-xs text-[var(--text-secondary)]" title={subtitle}>
+                  {subtitle}
+                </div>
+              ) : null}
+            </div>
+          </div>
+          {headerAside ? (
+            <div className="ml-[var(--space-2)] shrink-0 text-right text-xs text-[var(--text-tertiary)]">
+              {headerAside}
+            </div>
+          ) : null}
+        </div>
+
+        {children ? (
+          <div className="node-body space-y-[var(--space-2)] text-xs text-[var(--text-secondary)]">
+            {children}
+          </div>
+        ) : null}
+
+        {footer ? (
+          <div className="node-footer pt-[var(--space-2)] text-[10px] text-[var(--text-tertiary)]">
+            {footer}
+          </div>
+        ) : null}
+      </div>
+
+      {inputs.length > 0 ? (
+        <div
+          className="node-port-zone absolute flex flex-col gap-[var(--space-2)]"
+          style={leftZoneStyle}
+        >
+          {inputs.map((port, index) =>
+            renderPortRow(port, index, 'input', setInputRef(index))
+          )}
+        </div>
+      ) : null}
+
+      {outputs.length > 0 ? (
+        <div
+          className="node-port-zone absolute flex flex-col gap-[var(--space-2)]"
+          style={rightZoneStyle}
+        >
+          {outputs.map((port, index) =>
+            renderPortRow(port, index, 'output', setOutputRef(index))
+          )}
+        </div>
+      ) : null}
+    </Card>
+  );
+}

--- a/src/components/workspace/nodes/port-utils.ts
+++ b/src/components/workspace/nodes/port-utils.ts
@@ -1,0 +1,36 @@
+import type { NodePortDisplay, NodePortBadgeTone } from './node-layout';
+import type { PortDefinition } from '@/shared/types/ports';
+
+export interface PortOverride
+  extends Partial<Omit<NodePortDisplay, 'id' | 'label' | 'badge' | 'badgeTone'>> {
+  label?: string;
+  badge?: string;
+  badgeTone?: NodePortBadgeTone;
+  description?: string;
+}
+
+export type PortOverrides = Record<string, PortOverride>;
+
+export function buildPortDisplays(
+  ports: PortDefinition[] | undefined,
+  side: 'input' | 'output',
+  overrides: PortOverrides = {}
+): NodePortDisplay[] {
+  if (!ports || ports.length === 0) return [];
+
+  return ports.map((port) => {
+    const override = overrides[port.id] ?? {};
+    const defaultLabel = port.label.trim();
+    const label = override.label ?? defaultLabel;
+
+    return {
+      id: port.id,
+      label,
+      description: override.description ?? label,
+      badge: override.badge ?? (side === 'input' ? 'In' : 'Out'),
+      badgeTone: override.badgeTone ?? (side === 'input' ? 'neutral' : 'accent'),
+      icon: override.icon,
+      handleClassName: override.handleClassName,
+    } satisfies NodePortDisplay;
+  });
+}

--- a/src/components/workspace/nodes/rectangle-node.tsx
+++ b/src/components/workspace/nodes/rectangle-node.tsx
@@ -1,47 +1,42 @@
-// src/components/workspace/nodes/rectangle-node.tsx - Simplified single output port
+// src/components/workspace/nodes/rectangle-node.tsx - Geometry rectangle node with structured layout
 'use client';
 
-import { Handle, Position, type NodeProps } from 'reactflow';
-import { Card, CardHeader, CardContent } from '@/components/ui/card';
+import type { NodeProps } from 'reactflow';
+
+import { NodeLayout } from './node-layout';
+import { buildPortDisplays } from './port-utils';
 import { getNodeDefinition } from '@/shared/registry/registry-utils';
 import type { RectangleNodeData } from '@/shared/types/nodes';
 import { Square as SquareIcon } from 'lucide-react';
 
 export function RectangleNode({ data, selected }: NodeProps<RectangleNodeData>) {
   const nodeDefinition = getNodeDefinition('rectangle');
+  const outputs = buildPortDisplays(nodeDefinition?.ports.outputs, 'output', {
+    output: {
+      label: 'Rectangle shape for layout',
+      description: 'Supplies a rectangle geometry to feed into canvas or animation nodes.',
+    },
+  });
+
+  const width = data.width ?? 100;
+  const height = data.height ?? 60;
+  const subtitle = `${width}px × ${height}px`;
 
   return (
-    <Card selected={selected} className="min-w-[var(--node-min-width)] p-[var(--card-padding)]">
-      <CardHeader className="p-0 pb-[var(--space-3)]">
-        <div className="flex items-center gap-[var(--space-2)]">
-          <div
-            className="flex h-6 w-6 items-center justify-center rounded text-[var(--text-primary)]"
-            style={{ backgroundColor: '#4444ff' }} // Canvas default
-          >
-            <SquareIcon size={12} />
-          </div>
-          <span className="font-semibold text-[var(--text-primary)]">
-            {data.identifier.displayName}
-          </span>
-        </div>
-      </CardHeader>
-
-      <CardContent className="space-y-1 p-0 text-xs text-[var(--text-secondary)]">
-        <div>Width: {data.width || 100}px</div>
-        <div>Height: {data.height || 60}px</div>
-      </CardContent>
-
-      {/* Single output port */}
-      {nodeDefinition?.ports.outputs.map((port) => (
-        <Handle
-          key={port.id}
-          type="source"
-          position={Position.Right}
-          id={port.id}
-          className={`h-3 w-3 !border-2 !border-[var(--text-primary)] bg-[var(--node-geometry)]`}
-          style={{ top: `50%` }}
-        />
-      ))}
-    </Card>
+    <NodeLayout
+      selected={selected}
+      title={data.identifier.displayName}
+      subtitle={subtitle}
+      icon={<SquareIcon className="h-3 w-3" />}
+      iconBackgroundClass="bg-[var(--node-geometry)] text-[var(--text-primary)]"
+      inputs={[]}
+      outputs={outputs}
+      accentHandleClass="!bg-[var(--node-geometry)]"
+    >
+      <div className="flex items-center justify-between text-xs">
+        <span>Rounded corners</span>
+        <span className="font-medium text-[var(--text-primary)]">Use canvas styles</span>
+      </div>
+    </NodeLayout>
   );
 }

--- a/src/components/workspace/nodes/result-node.tsx
+++ b/src/components/workspace/nodes/result-node.tsx
@@ -1,13 +1,15 @@
-// src/components/workspace/nodes/result-node.tsx - Production-ready debug node with modal viewer
+// src/components/workspace/nodes/result-node.tsx - Debug result node with structured layout
 'use client';
 
 import { useState } from 'react';
-import { Handle, Position, type NodeProps } from 'reactflow';
-import { Card, CardHeader, CardContent } from '@/components/ui/card';
+import type { NodeProps } from 'reactflow';
+
+import { NodeLayout } from './node-layout';
+import { buildPortDisplays } from './port-utils';
 import { Button } from '@/components/ui/button';
+import { useDebugContext } from '../flow/debug-context';
 import { getNodeDefinition } from '@/shared/registry/registry-utils';
 import type { ResultNodeData } from '@/shared/types/nodes';
-import { useDebugContext } from '../flow/debug-context';
 import { logger } from '@/lib/logger';
 import { Target } from 'lucide-react';
 
@@ -18,14 +20,25 @@ interface ResultNodeProps extends NodeProps<ResultNodeData> {
 export function ResultNode({ data, selected, onOpenLogViewer }: ResultNodeProps) {
   const nodeDefinition = getNodeDefinition('result');
   const [isRunning, setIsRunning] = useState(false);
-
-  // Use debug context if available
   const debugContext = useDebugContext();
   const onRunToHere = debugContext?.runToNode;
 
+  const inputs = buildPortDisplays(nodeDefinition?.ports.inputs, 'input', {
+    input: {
+      label: 'Value to inspect',
+      description: 'Attach any data stream you want to preview or debug.',
+    },
+  });
+
+  const outputs = buildPortDisplays(nodeDefinition?.ports.outputs, 'output', {
+    output: {
+      label: 'Forwarded debug value',
+      description: 'Outputs the same value so the flow continues after inspection.',
+    },
+  });
+
   const handleRunToHere = async () => {
     if (!onRunToHere) return;
-
     setIsRunning(true);
     try {
       await onRunToHere(data.identifier.id);
@@ -42,61 +55,29 @@ export function ResultNode({ data, selected, onOpenLogViewer }: ResultNodeProps)
     }
   };
 
-  const handleClass = 'bg-[var(--node-output)]';
-
   return (
-    <Card
+    <NodeLayout
       selected={selected}
-      className="min-w-[var(--node-min-width)] cursor-pointer p-[var(--card-padding)] transition-all hover:bg-[var(--surface-interactive)]"
+      className="cursor-pointer transition-colors hover:bg-[var(--surface-interactive)]"
+      title={data.identifier.displayName}
+      subtitle="Inspect values while keeping the flow running"
+      icon={<Target className="h-3 w-3" />}
+      iconBackgroundClass="bg-[var(--node-output)] text-[var(--text-primary)]"
+      inputs={inputs}
+      outputs={outputs}
+      accentHandleClass="!bg-[var(--node-output)]"
       onDoubleClick={handleDoubleClick}
+      footer="Double-click to open the debug log viewer"
     >
-      {/* Single input port */}
-      {nodeDefinition?.ports.inputs.map((port) => (
-        <Handle
-          key={port.id}
-          type="target"
-          position={Position.Left}
-          id={port.id}
-          className={`h-3 w-3 ${handleClass} !border-2 !border-[var(--text-primary)]`}
-          style={{ top: `35%` }}
-        />
-      ))}
-      {/* New output port to expose variable value */}
-      {nodeDefinition?.ports.outputs.map((port) => (
-        <Handle
-          key={port.id}
-          type="source"
-          position={Position.Right}
-          id={port.id}
-          className={`h-3 w-3 ${handleClass} !border-2 !border-[var(--text-primary)]`}
-          style={{ top: `35%` }}
-        />
-      ))}
-
-      <CardHeader className="p-0 pb-[var(--space-3)]">
-        <div className="flex items-center gap-[var(--space-2)]">
-          <div className="flex h-6 w-6 items-center justify-center rounded bg-[var(--node-output)] text-[var(--text-primary)]">
-            <Target size={12} />
-          </div>
-          <div className="min-w-0 flex-1">
-            <div className="truncate font-semibold text-[var(--text-primary)]">
-              {data.identifier.displayName}
-            </div>
-          </div>
-        </div>
-      </CardHeader>
-
-      <CardContent className="space-y-[var(--space-3)] p-0">
-        <Button
-          onClick={handleRunToHere}
-          disabled={isRunning || !onRunToHere}
-          variant="primary"
-          size="sm"
-          className="w-full"
-        >
-          {isRunning ? 'Running...' : 'Run to Here'}
-        </Button>
-      </CardContent>
-    </Card>
+      <Button
+        onClick={handleRunToHere}
+        disabled={isRunning || !onRunToHere}
+        variant="primary"
+        size="sm"
+        className="w-full"
+      >
+        {isRunning ? 'Running…' : 'Run to Here'}
+      </Button>
+    </NodeLayout>
   );
 }

--- a/src/components/workspace/nodes/scene-node.tsx
+++ b/src/components/workspace/nodes/scene-node.tsx
@@ -1,14 +1,23 @@
-// src/components/workspace/nodes/scene-node.tsx - Simplified single input port
+// src/components/workspace/nodes/scene-node.tsx - Scene output configuration with structured layout
 'use client';
 
-import { Handle, Position, type NodeProps } from 'reactflow';
-import { Card, CardHeader, CardContent } from '@/components/ui/card';
+import type { NodeProps } from 'reactflow';
+
+import { NodeLayout } from './node-layout';
+import { buildPortDisplays } from './port-utils';
 import { getNodeDefinition } from '@/shared/registry/registry-utils';
 import type { SceneNodeData } from '@/shared/types/nodes';
 import { MonitorPlay } from 'lucide-react';
 
 export function SceneNode({ data, selected }: NodeProps<SceneNodeData>) {
   const nodeDefinition = getNodeDefinition('scene');
+
+  const inputs = buildPortDisplays(nodeDefinition?.ports.inputs, 'input', {
+    input: {
+      label: 'Final scene stream',
+      description: 'Connect your composed scene or animation before rendering.',
+    },
+  });
 
   const getResolutionLabel = (width: number, height: number) => {
     if (width === 1920 && height === 1080) return 'FHD';
@@ -18,85 +27,52 @@ export function SceneNode({ data, selected }: NodeProps<SceneNodeData>) {
     return 'Custom';
   };
 
-  const getQualityLabel = (crf: number) => {
+  const width = data.width;
+  const height = data.height;
+  const fps = data.fps;
+  const duration = data.duration;
+  const subtitle = `${width}×${height} • ${fps} FPS • ${duration}s`;
+
+  const qualityLabel = (crf: number) => {
     if (crf <= 18) return 'High';
     if (crf <= 28) return 'Medium';
     return 'Low';
   };
 
-  const handleClass = 'bg-[var(--node-output)]';
-
   return (
-    <Card selected={selected} className="min-w-[var(--node-min-width)] p-[var(--card-padding)]">
-      {/* Single input port */}
-      {nodeDefinition?.ports.inputs.map((port) => (
-        <Handle
-          key={port.id}
-          type="target"
-          position={Position.Left}
-          id={port.id}
-          className={`h-3 w-3 ${handleClass} !border-2 !border-[var(--text-primary)]`}
-          style={{ top: `50%` }}
-        />
-      ))}
-
-      <CardHeader className="p-0 pb-[var(--space-3)]">
+    <NodeLayout
+      selected={selected}
+      title={data.identifier.displayName}
+      subtitle={subtitle}
+      icon={<MonitorPlay className="h-3 w-3" />}
+      iconBackgroundClass="bg-[var(--node-output)] text-[var(--text-primary)]"
+      inputs={inputs}
+      outputs={[]}
+      accentHandleClass="!bg-[var(--node-output)]"
+      footer="Defines the final video output"
+    >
+      <div className="flex items-center justify-between text-xs">
+        <span>Resolution</span>
+        <span className="font-medium text-[var(--text-primary)]">
+          {getResolutionLabel(width, height)} ({width}×{height})
+        </span>
+      </div>
+      <div className="flex items-center justify-between text-xs">
+        <span>Background</span>
         <div className="flex items-center gap-[var(--space-2)]">
-          <div className="flex h-6 w-6 items-center justify-center rounded bg-[var(--node-output)] text-[var(--text-primary)]">
-            <MonitorPlay size={12} />
-          </div>
-          <div className="min-w-0 flex-1">
-            <div className="truncate font-semibold text-[var(--text-primary)]">
-              {data.identifier.displayName}
-            </div>
-          </div>
+          <div
+            className="h-4 w-4 rounded border border-[var(--border-primary)]"
+            style={{ backgroundColor: data.backgroundColor }}
+          />
+          <span className="font-medium text-[var(--text-primary)]">{data.backgroundColor.toUpperCase()}</span>
         </div>
-      </CardHeader>
-
-      <CardContent className="space-y-2 p-0 text-xs text-[var(--text-secondary)]">
-        <div className="flex items-center justify-between">
-          <span>Resolution</span>
-          <span className="font-medium text-[var(--text-primary)]">
-            {getResolutionLabel(data.width, data.height)} ({data.width}×{data.height})
-          </span>
-        </div>
-
-        <div className="flex items-center justify-between">
-          <span>Frame Rate</span>
-          <span className="font-medium text-[var(--text-primary)]">{data.fps} FPS</span>
-        </div>
-
-        <div className="flex items-center justify-between">
-          <span>Duration</span>
-          <span className="font-medium text-[var(--text-primary)]">{data.duration}s</span>
-        </div>
-
-        <div className="flex items-center justify-between">
-          <span>Background</span>
-          <div className="flex items-center gap-[var(--space-2)]">
-            <div
-              className="h-4 w-4 rounded border border-[var(--border-primary)]"
-              style={{ backgroundColor: data.backgroundColor }}
-            />
-            <span className="text-xs font-medium text-[var(--text-primary)]">
-              {data.backgroundColor.toUpperCase()}
-            </span>
-          </div>
-        </div>
-
-        <div className="flex items-center justify-between">
-          <span>Quality</span>
-          <span className="font-medium text-[var(--text-primary)]">
-            {getQualityLabel(data.videoCrf)} ({data.videoPreset})
-          </span>
-        </div>
-
-        <div className="mt-4 border-t border-[var(--border-primary)] pt-3">
-          <div className="text-center text-xs text-[var(--text-tertiary)]">
-            {data.width}×{data.height} @ {data.fps}fps
-          </div>
-        </div>
-      </CardContent>
-    </Card>
+      </div>
+      <div className="flex items-center justify-between text-xs">
+        <span>Encoding</span>
+        <span className="font-medium text-[var(--text-primary)]">
+          {qualityLabel(data.videoCrf)} • {data.videoPreset}
+        </span>
+      </div>
+    </NodeLayout>
   );
 }

--- a/src/components/workspace/nodes/text-node.tsx
+++ b/src/components/workspace/nodes/text-node.tsx
@@ -1,7 +1,9 @@
 'use client';
 
-import { Handle, Position, type NodeProps } from 'reactflow';
-import { Card, CardHeader, CardContent } from '@/components/ui/card';
+import type { NodeProps } from 'reactflow';
+
+import { NodeLayout } from './node-layout';
+import { buildPortDisplays } from './port-utils';
 import { getNodeDefinition } from '@/shared/registry/registry-utils';
 import type { TextNodeData } from '@/shared/types/nodes';
 import { Type } from 'lucide-react';
@@ -9,41 +11,36 @@ import { Type } from 'lucide-react';
 export function TextNode({ data, selected }: NodeProps<TextNodeData>) {
   const nodeDefinition = getNodeDefinition('text');
 
-  const displayContent =
-    data.content?.length > 20
-      ? data.content.substring(0, 20) + '...'
-      : data.content || 'Hello World';
+  const outputs = buildPortDisplays(nodeDefinition?.ports.outputs, 'output', {
+    output: {
+      label: 'Text content for scene layout',
+      description: 'Sends styled text content to typography or animation nodes.',
+    },
+  });
+
+  const content = data.content?.trim() || 'Hello World';
+  const preview = content.length > 28 ? `${content.substring(0, 25)}…` : content;
+  const fontSize = data.fontSize ?? 24;
 
   return (
-    <Card selected={selected} className="min-w-[var(--node-min-width)] p-[var(--card-padding)]">
-      <CardHeader className="p-0 pb-[var(--space-3)]">
-        <div className="flex items-center gap-[var(--space-2)]">
-          <div className="flex h-6 w-6 items-center justify-center rounded bg-[var(--node-text)] text-[var(--text-primary)]">
-            <Type size={12} />
-          </div>
-          <span className="font-semibold text-[var(--text-primary)]">
-            {data.identifier.displayName}
-          </span>
-        </div>
-      </CardHeader>
-
-      <CardContent className="space-y-1 p-0 text-xs text-[var(--text-secondary)]">
-        <div className="rounded bg-[var(--surface-2)] p-1 font-mono text-[10px]">
-          &ldquo;{displayContent}&rdquo;
-        </div>
-        <div>Size: {data.fontSize || 24}px</div>
-      </CardContent>
-
-      {nodeDefinition?.ports.outputs.map((port) => (
-        <Handle
-          key={port.id}
-          type="source"
-          position={Position.Right}
-          id={port.id}
-          className="h-3 w-3 !border-2 !border-[var(--text-primary)] bg-[var(--node-text)]"
-          style={{ top: '50%' }}
-        />
-      ))}
-    </Card>
+    <NodeLayout
+      selected={selected}
+      title={data.identifier.displayName}
+      subtitle={`Preview: ${preview}`}
+      icon={<Type className="h-3 w-3" />}
+      iconBackgroundClass="bg-[var(--node-text)] text-[var(--text-primary)]"
+      inputs={[]}
+      outputs={outputs}
+      accentHandleClass="!bg-[var(--node-text)]"
+      footer="Double-click to edit text in the Typography tab"
+    >
+      <div className="rounded bg-[var(--surface-2)]/80 px-[var(--space-2)] py-[var(--space-1)] font-mono text-[10px] text-[var(--text-primary)]">
+        “{preview}”
+      </div>
+      <div className="flex items-center justify-between text-xs">
+        <span>Font size</span>
+        <span className="font-medium text-[var(--text-primary)]">{fontSize}px</span>
+      </div>
+    </NodeLayout>
   );
 }

--- a/src/components/workspace/nodes/triangle-node.tsx
+++ b/src/components/workspace/nodes/triangle-node.tsx
@@ -1,46 +1,41 @@
-// src/components/workspace/nodes/triangle-node.tsx - Simplified single output port
+// src/components/workspace/nodes/triangle-node.tsx - Geometry triangle node with visual port layout
 'use client';
 
-import { Handle, Position, type NodeProps } from 'reactflow';
-import { Card, CardHeader, CardContent } from '@/components/ui/card';
+import type { NodeProps } from 'reactflow';
+
+import { NodeLayout } from './node-layout';
+import { buildPortDisplays } from './port-utils';
 import { getNodeDefinition } from '@/shared/registry/registry-utils';
 import type { TriangleNodeData } from '@/shared/types/nodes';
 import { Triangle as TriangleIcon } from 'lucide-react';
 
 export function TriangleNode({ data, selected }: NodeProps<TriangleNodeData>) {
   const nodeDefinition = getNodeDefinition('triangle');
+  const outputs = buildPortDisplays(nodeDefinition?.ports.outputs, 'output', {
+    output: {
+      label: 'Triangle shape for downstream styling',
+      description: 'Provides the triangle geometry to layer, animate, or style in canvas nodes.',
+    },
+  });
+
+  const size = data.size ?? 80;
+  const subtitle = `Edge length ${size}px`;
 
   return (
-    <Card selected={selected} className="min-w-[var(--node-min-width)] p-[var(--card-padding)]">
-      <CardHeader className="p-0 pb-[var(--space-3)]">
-        <div className="flex items-center gap-[var(--space-2)]">
-          <div
-            className="flex h-6 w-6 items-center justify-center rounded text-[var(--text-primary)]"
-            style={{ backgroundColor: '#4444ff' }} // Canvas default
-          >
-            <TriangleIcon size={12} />
-          </div>
-          <span className="font-semibold text-[var(--text-primary)]">
-            {data.identifier.displayName}
-          </span>
-        </div>
-      </CardHeader>
-
-      <CardContent className="space-y-1 p-0 text-xs text-[var(--text-secondary)]">
-        <div>Size: {data.size || 80}px</div>
-      </CardContent>
-
-      {/* Single output port */}
-      {nodeDefinition?.ports.outputs.map((port) => (
-        <Handle
-          key={port.id}
-          type="source"
-          position={Position.Right}
-          id={port.id}
-          className={`h-3 w-3 !border-2 !border-[var(--text-primary)] bg-[var(--node-geometry)]`}
-          style={{ top: `50%` }}
-        />
-      ))}
-    </Card>
+    <NodeLayout
+      selected={selected}
+      title={data.identifier.displayName}
+      subtitle={subtitle}
+      icon={<TriangleIcon className="h-3 w-3" />}
+      iconBackgroundClass="bg-[var(--node-geometry)] text-[var(--text-primary)]"
+      inputs={[]}
+      outputs={outputs}
+      accentHandleClass="!bg-[var(--node-geometry)]"
+    >
+      <div className="flex items-center justify-between text-xs">
+        <span>Default fill</span>
+        <span className="font-medium text-[var(--text-primary)]">Workspace accent</span>
+      </div>
+    </NodeLayout>
   );
 }

--- a/src/components/workspace/nodes/typography-node.tsx
+++ b/src/components/workspace/nodes/typography-node.tsx
@@ -1,10 +1,12 @@
 'use client';
 
-import { Handle, Position, type NodeProps } from 'reactflow';
-import { Card, CardHeader, CardContent } from '@/components/ui/card';
+import type { NodeProps } from 'reactflow';
+
+import { NodeLayout } from './node-layout';
+import { buildPortDisplays } from './port-utils';
 import { getNodeDefinition } from '@/shared/registry/registry-utils';
 import type { TypographyNodeData } from '@/shared/types/nodes';
-import { Type, Settings } from 'lucide-react';
+import { Settings, Type } from 'lucide-react';
 
 interface TypographyNodeProps extends NodeProps<TypographyNodeData> {
   onOpenTypography?: () => void;
@@ -13,10 +15,23 @@ interface TypographyNodeProps extends NodeProps<TypographyNodeData> {
 export function TypographyNode({ data, selected, onOpenTypography }: TypographyNodeProps) {
   const nodeDefinition = getNodeDefinition('typography');
 
+  const inputs = buildPortDisplays(nodeDefinition?.ports.inputs, 'input', {
+    input: {
+      label: 'Text objects to style',
+      description: 'Feed raw text objects to apply typography presets.',
+    },
+  });
+
+  const outputs = buildPortDisplays(nodeDefinition?.ports.outputs, 'output', {
+    output: {
+      label: 'Typography-styled text',
+      description: 'Produces text objects with the selected typography applied.',
+    },
+  });
+
   const handleDoubleClick = () => {
     if (onOpenTypography) return onOpenTypography();
 
-    // Fallback URL navigation (follows AnimationNode pattern)
     const params = new URLSearchParams(window.location.search);
     const ws = params.get('workspace');
     const url = new URL(window.location.href);
@@ -26,58 +41,32 @@ export function TypographyNode({ data, selected, onOpenTypography }: TypographyN
     window.history.pushState({}, '', url.toString());
   };
 
-  const currentFont = `${data.fontFamily || 'Arial'} ${data.fontWeight || 'normal'}`;
-
+  const fontFamily = data.fontFamily || 'Arial';
+  const fontWeight = data.fontWeight || 'normal';
+  const subtitle = `${fontFamily} ${fontWeight}`;
   return (
-    <Card
+    <NodeLayout
       selected={selected}
-      className="min-w-[var(--node-min-width)] cursor-pointer p-[var(--card-padding)] transition-all hover:bg-[var(--surface-interactive)]"
+      className="cursor-pointer transition-colors hover:bg-[var(--surface-interactive)]"
+      title={data?.identifier?.displayName ?? 'Typography'}
+      subtitle={subtitle}
+      icon={<Type className="h-3 w-3" />}
+      iconBackgroundClass="bg-[var(--node-animation)] text-[var(--text-primary)]"
+      headerAside={<Settings className="h-3 w-3 text-[var(--text-tertiary)]" />}
+      inputs={inputs}
+      outputs={outputs}
+      accentHandleClass="!bg-[var(--node-animation)]"
       onDoubleClick={handleDoubleClick}
+      footer="Double-click to open the Typography editor"
     >
-      {nodeDefinition?.ports.inputs.map((port) => (
-        <Handle
-          key={port.id}
-          type="target"
-          position={Position.Left}
-          id={port.id}
-          className="h-3 w-3 !border-2 !border-[var(--text-primary)] bg-[var(--node-animation)]"
-          style={{ top: '50%' }}
-        />
-      ))}
-
-      <CardHeader className="p-0 pb-[var(--space-3)]">
-        <div className="flex items-center gap-[var(--space-2)]">
-          <div className="flex h-6 w-6 items-center justify-center rounded bg-[var(--node-animation)] text-[var(--text-primary)]">
-            <Type size={12} />
-          </div>
-          <div className="min-w-0 flex-1">
-            <div className="truncate font-semibold text-[var(--text-primary)]">
-              {data?.identifier?.displayName ?? 'Typography'}
-            </div>
-          </div>
-          <Settings size={12} className="text-[var(--text-tertiary)]" />
-        </div>
-      </CardHeader>
-
-      <CardContent className="space-y-1 p-0 text-xs text-[var(--text-secondary)]">
-        <div className="truncate">Font: {currentFont}</div>
-        <div>Align: {data.textAlign || 'center'}</div>
-        <div>Line Height: {data.lineHeight || 1.2}</div>
-        <div className="pt-1 text-[10px] text-[var(--text-tertiary)]">
-          Double-click to edit in Typography tab
-        </div>
-      </CardContent>
-
-      {nodeDefinition?.ports.outputs.map((port) => (
-        <Handle
-          key={port.id}
-          type="source"
-          position={Position.Right}
-          id={port.id}
-          className="h-3 w-3 !border-2 !border-[var(--text-primary)] bg-[var(--node-animation)]"
-          style={{ top: '50%' }}
-        />
-      ))}
-    </Card>
+      <div className="flex items-center justify-between text-xs">
+        <span>Align</span>
+        <span className="font-medium text-[var(--text-primary)]">{data.textAlign || 'center'}</span>
+      </div>
+      <div className="flex items-center justify-between text-xs">
+        <span>Line height</span>
+        <span className="font-medium text-[var(--text-primary)]">{data.lineHeight ?? 1.2}</span>
+      </div>
+    </NodeLayout>
   );
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -506,3 +506,28 @@ body {
     box-shadow: 0 0 20px rgba(139, 92, 246, 0.2);
   }
 }
+
+/* Workspace node layout helpers */
+.node-center-zone {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.node-subtitle,
+.node-port-label-text {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  white-space: normal;
+  word-break: break-word;
+  text-overflow: ellipsis;
+}
+
+.node-subtitle {
+  -webkit-line-clamp: 2;
+}
+
+.node-port-label-text {
+  -webkit-line-clamp: 2;
+}


### PR DESCRIPTION
## Summary
- introduce a shared `NodeLayout` with batched port measurement and three-zone node layout helpers
- update all workspace node components to use the new layout and provide concise, plain-language port badges
- add supporting styling utilities to clamp node text, prevent overlaps, and align icons/badges consistently

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68ce82b7edd88322bc27dce7af354076