### PR TITLE
Improve flow node layout readability

### DIFF
--- a/src/components/workspace/nodes/batch-node.tsx
+++ b/src/components/workspace/nodes/batch-node.tsx
@@ -1,14 +1,12 @@
 'use client';
 
-import React from 'react';
-import { Handle, Position } from 'reactflow';
+import { useMemo, useState } from 'react';
 import { useWorkspace } from '@/components/workspace/workspace-context';
 import { Input } from '@/components/ui/input';
-
-import { Card, CardHeader, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Modal } from '@/components/ui/modal';
 import { getNodeDefinition } from '@/shared/registry/registry-utils';
+import { NodeLayout, type PortConfig } from './components/node-layout';
 import type { NodeData } from '@/shared/types/nodes';
 
 export function BatchNode({ id }: { id: string }) {
@@ -16,164 +14,165 @@ export function BatchNode({ id }: { id: string }) {
   const node = state.flow.nodes.find((n) => n.id === id);
   const nodeId = node?.data?.identifier?.id ?? id;
 
-  const data = (node?.data ?? {}) as unknown as Record<string, unknown> & {
+  const data = (node?.data ?? {}) as Record<string, unknown> & {
     keys?: string[];
     variableBindings?: Record<string, { boundResultNodeId?: string }>;
   };
   const keys = Array.isArray(data.keys)
-    ? (data.keys as unknown[]).filter((k) => typeof k === 'string')
+    ? (data.keys as unknown[]).filter((k): k is string => typeof k === 'string')
     : [];
 
-  const [open, setOpen] = React.useState(false);
-  const [localInput, setLocalInput] = React.useState('');
+  const [open, setOpen] = useState(false);
+  const [localInput, setLocalInput] = useState('');
 
   const nodeDefinition = getNodeDefinition('batch');
-  const handleClass = 'bg-[var(--node-logic)]';
+
+  const inputs = useMemo<PortConfig[]>(() => {
+    const definitions = nodeDefinition?.ports.inputs ?? [];
+    if (definitions.length === 0) {
+      return [
+        {
+          id: 'input',
+          label: 'Stream to batch',
+          tooltip: 'Incoming data that should be processed in batches',
+          handleClassName: 'bg-[var(--node-logic)]',
+          handleProps: { onDoubleClick: (event) => event.stopPropagation() },
+        },
+      ];
+    }
+
+    return definitions.map((port) => ({
+      id: port.id,
+      label: 'Stream to batch',
+      tooltip: 'Incoming data that should be processed in batches',
+      handleClassName: 'bg-[var(--node-logic)]',
+      handleProps: { onDoubleClick: (event) => event.stopPropagation() },
+    }));
+  }, [nodeDefinition]);
+
+  const outputs = useMemo<PortConfig[]>(() => {
+    const definitions = nodeDefinition?.ports.outputs ?? [];
+    if (definitions.length === 0) {
+      return [
+        {
+          id: 'output',
+          label: 'Batch results',
+          tooltip: 'Emits one result per key for each item in the batch',
+          handleClassName: 'bg-[var(--node-logic)]',
+          handleProps: { onDoubleClick: (event) => event.stopPropagation() },
+        },
+      ];
+    }
+
+    return definitions.map((port) => ({
+      id: port.id,
+      label: 'Batch results',
+      tooltip: 'Emits one result per key for each item in the batch',
+      handleClassName: 'bg-[var(--node-logic)]',
+      handleProps: { onDoubleClick: (event) => event.stopPropagation() },
+    }));
+  }, [nodeDefinition]);
+
+  const handleAddKey = () => {
+    const value = localInput.trim();
+    if (!value || keys.includes(value)) return;
+    const nextKeys = [...keys, value];
+    updateFlow({
+      nodes: state.flow.nodes.map((n) =>
+        n.id !== id
+          ? n
+          : {
+              ...n,
+              data: {
+                ...n.data,
+                keys: nextKeys,
+              } as NodeData,
+            },
+      ),
+    });
+    if (typeof window !== 'undefined') {
+      window.dispatchEvent(
+        new CustomEvent('batch-keys-updated', {
+          detail: {
+            nodeIdentifierId: nodeId,
+            keys: [...nextKeys],
+          },
+        }),
+      );
+    }
+    setLocalInput('');
+  };
+
+  const handleRemoveKey = (key: string) => {
+    const nextKeys = keys.filter((k) => k !== key);
+    updateFlow({
+      nodes: state.flow.nodes.map((n) =>
+        n.id !== id
+          ? n
+          : {
+              ...n,
+              data: {
+                ...n.data,
+                keys: nextKeys,
+              } as NodeData,
+            },
+      ),
+    });
+    if (typeof window !== 'undefined') {
+      window.dispatchEvent(
+        new CustomEvent('batch-keys-updated', {
+          detail: {
+            nodeIdentifierId: nodeId,
+            keys: [...nextKeys],
+          },
+        }),
+      );
+    }
+  };
 
   return (
-    <Card
-      className="min-w-[var(--node-min-width)] cursor-pointer p-[var(--card-padding)]"
-      onDoubleClick={() => setOpen(true)}
-    >
-      {nodeDefinition?.ports.inputs.map((port) => (
-        <Handle
-          key={port.id}
-          type="target"
-          position={Position.Left}
-          id={port.id}
-          className={`h-3 w-3 ${handleClass} !border-2 !border-[var(--text-primary)]`}
-          style={{ top: `50%` }}
-          onDoubleClick={(e) => e.stopPropagation()}
-        />
-      ))}
-
-      <CardHeader className="p-0 pb-[var(--space-3)]">
+    <>
+      <NodeLayout
+        selected={Boolean(node?.selected)}
+        title={node?.data?.identifier?.displayName ?? 'Batch'}
+        subtitle={`${keys.length} key${keys.length === 1 ? '' : 's'} configured`}
+        icon={<span role="img" aria-label="batch">🏷️</span>}
+        iconClassName="bg-[var(--node-logic)]"
+        inputs={inputs}
+        outputs={outputs}
+        onDoubleClick={() => setOpen(true)}
+        measureDeps={[keys.length]}
+        className="cursor-pointer"
+        footer="Double-click or press Keys to manage batch outputs"
+      >
         <div className="flex items-center gap-[var(--space-2)]">
-          <div className="flex h-6 w-6 items-center justify-center rounded bg-[var(--node-logic)] text-[var(--text-primary)]">
-            <span role="img" aria-label="batch">
-              🏷️
-            </span>
-          </div>
-          <span className="font-semibold text-[var(--text-primary)]">
-            {node?.data?.identifier?.displayName ?? 'Batch'}
-          </span>
-          <span className="ml-auto text-[10px] text-[var(--text-secondary)]">
-            {keys.length} keys
-          </span>
-        </div>
-      </CardHeader>
-
-      <CardContent className="space-y-2 p-0">
-        <div className="flex items-center gap-[var(--space-2)]">
-          <Button variant="secondary" onClick={() => setOpen(true)}>
+          <Button variant="secondary" size="sm" onClick={() => setOpen(true)}>
             Keys
           </Button>
-          <div className="text-[10px] text-[var(--text-tertiary)]">Manage keys</div>
+          <span className="text-[10px] text-[var(--text-tertiary)]">Manage key list</span>
         </div>
-      </CardContent>
-
-      {nodeDefinition?.ports.outputs.map((port) => (
-        <Handle
-          key={port.id}
-          type="source"
-          position={Position.Right}
-          id={port.id}
-          className={`h-3 w-3 ${handleClass} !border-2 !border-[var(--text-primary)]`}
-          style={{ top: `50%` }}
-          onDoubleClick={(e) => e.stopPropagation()}
-        />
-      ))}
+      </NodeLayout>
 
       {open ? (
         <Modal isOpen={open} onClose={() => setOpen(false)} title="Batch Keys" size="sm">
           <div className="p-[var(--space-4)]">
-            <div className="mb-[var(--space-2)] text-[12px] text-[var(--text-secondary)]">
-              Add or remove keys
-            </div>
+            <div className="mb-[var(--space-2)] text-[12px] text-[var(--text-secondary)]">Add or remove keys</div>
             <div className="flex gap-[var(--space-2)]">
-              <Input
-                placeholder="Enter key"
-                value={localInput}
-                onChange={(e) => setLocalInput(e.target.value)}
-              />
-              <Button
-                onClick={() => {
-                  const v = localInput.trim();
-                  if (!v) return;
-                  if (keys.includes(v)) return; // prevent duplicates
-                  const nextKeys = [...keys, v];
-                  // Autosave like layer modal: update flow immediately
-                  updateFlow({
-                    nodes: state.flow.nodes.map((n) =>
-                      n.id !== id
-                        ? n
-                        : {
-                            ...n,
-                            data: {
-                              ...n.data,
-                              keys: nextKeys,
-                            } as NodeData,
-                          }
-                    ),
-                  });
-                  // Notify FlowEditorTab to sync its local nodes to prevent snap-back overwrite
-                  if (typeof window !== 'undefined') {
-                    window.dispatchEvent(
-                      new CustomEvent('batch-keys-updated', {
-                        detail: {
-                          nodeIdentifierId: nodeId,
-                          keys: [...nextKeys],
-                        },
-                      })
-                    );
-                  }
-                  setLocalInput('');
-                }}
-              >
-                Add
-              </Button>
+              <Input placeholder="Enter key" value={localInput} onChange={(event) => setLocalInput(event.target.value)} />
+              <Button onClick={handleAddKey}>Add</Button>
             </div>
 
             <div className="mt-[var(--space-3)] space-y-[var(--space-2)]">
               {keys.length === 0 ? (
                 <div className="text-[12px] text-[var(--text-tertiary)]">No keys yet.</div>
               ) : (
-                keys.map((k) => (
+                keys.map((key) => (
                   <div
-                    key={k}
+                    key={key}
                     className="flex items-center justify-between rounded border border-[var(--border)] px-[var(--space-2)] py-[var(--space-1)]"
                   >
-                    <div className="text-[12px]">{k}</div>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => {
-                        const nextKeys = keys.filter((x) => x !== k);
-                        updateFlow({
-                          nodes: state.flow.nodes.map((n) =>
-                            n.id !== id
-                              ? n
-                              : {
-                                  ...n,
-                                  data: {
-                                    ...n.data,
-                                    keys: nextKeys,
-                                  } as NodeData,
-                                }
-                          ),
-                        });
-                        if (typeof window !== 'undefined') {
-                          window.dispatchEvent(
-                            new CustomEvent('batch-keys-updated', {
-                              detail: {
-                                nodeIdentifierId: nodeId,
-                                keys: [...nextKeys],
-                              },
-                            })
-                          );
-                        }
-                      }}
-                    >
+                    <div className="text-[12px]">{key}</div>
+                    <Button variant="ghost" size="sm" onClick={() => handleRemoveKey(key)}>
                       Remove
                     </Button>
                   </div>
@@ -187,6 +186,6 @@ export function BatchNode({ id }: { id: string }) {
           </div>
         </Modal>
       ) : null}
-    </Card>
+    </>
   );
 }

--- a/src/components/workspace/nodes/boolean-op-node.tsx
+++ b/src/components/workspace/nodes/boolean-op-node.tsx
@@ -1,112 +1,116 @@
-// src/components/workspace/nodes/boolean-op-node.tsx - Boolean operation logic node
 'use client';
 
-import { Handle, Position, type NodeProps } from 'reactflow';
-import { Card, CardHeader, CardContent } from '@/components/ui/card';
-import { getNodeDefinitionWithDynamicPorts } from '@/shared/registry/registry-utils';
-import type { BooleanOpNodeData } from '@/shared/types/nodes';
+import { useMemo } from 'react';
+import type { NodeProps } from 'reactflow';
 import { Binary } from 'lucide-react';
+import { getNodeDefinitionWithDynamicPorts } from '@/shared/registry/registry-utils';
+import { NodeLayout, type PortConfig } from './components/node-layout';
+import type { BooleanOpNodeData } from '@/shared/types/nodes';
+
+function getOperatorLabel(operator: BooleanOpNodeData['operator']) {
+  switch (operator) {
+    case 'and':
+      return 'AND';
+    case 'or':
+      return 'OR';
+    case 'not':
+      return 'NOT';
+    case 'xor':
+      return 'XOR';
+    default:
+      return 'Boolean';
+  }
+}
+
+function getOperatorSymbol(operator: BooleanOpNodeData['operator']) {
+  switch (operator) {
+    case 'and':
+      return '∧';
+    case 'or':
+      return '∨';
+    case 'not':
+      return '¬';
+    case 'xor':
+      return '⊕';
+    default:
+      return '?';
+  }
+}
 
 export function BooleanOpNode({ data, selected }: NodeProps<BooleanOpNodeData>) {
-  const nodeDefinition = getNodeDefinitionWithDynamicPorts(
-    'boolean_op',
-    data as unknown as Record<string, unknown>
-  );
+  const nodeDefinition = getNodeDefinitionWithDynamicPorts('boolean_op', data as unknown as Record<string, unknown>);
 
-  const getOperatorDisplay = () => {
-    switch (data.operator) {
-      case 'and':
-        return 'AND';
-      case 'or':
-        return 'OR';
-      case 'not':
-        return 'NOT';
-      case 'xor':
-        return 'XOR';
+  const inputs = useMemo<PortConfig[]>(() => {
+    const definitions = nodeDefinition?.ports.inputs ?? [];
+    if (definitions.length === 0) {
+      return [
+        {
+          id: 'input_1',
+          label: 'Input 1',
+          tooltip: 'Boolean input',
+          handleClassName: 'bg-[var(--node-logic)]',
+          badge: '1',
+        },
+        {
+          id: 'input_2',
+          label: 'Input 2',
+          tooltip: 'Boolean input',
+          handleClassName: 'bg-[var(--node-logic)]',
+          badge: '2',
+        },
+      ];
     }
-  };
 
-  const getOperatorSymbol = () => {
-    switch (data.operator) {
-      case 'and':
-        return '∧';
-      case 'or':
-        return '∨';
-      case 'not':
-        return '¬';
-      case 'xor':
-        return '⊕';
+    return definitions.map((port, index) => ({
+      id: port.id,
+      label: `Input ${index + 1}`,
+      tooltip: 'Boolean input',
+      handleClassName: 'bg-[var(--node-logic)]',
+      badge: String(index + 1),
+    }));
+  }, [nodeDefinition]);
+
+  const outputs = useMemo<PortConfig[]>(() => {
+    const definitions = nodeDefinition?.ports.outputs ?? [];
+    if (definitions.length === 0) {
+      return [
+        {
+          id: 'output',
+          label: 'Boolean result',
+          tooltip: 'Result of the boolean operation',
+          handleClassName: 'bg-[var(--node-logic)]',
+        },
+      ];
     }
-  };
 
-  const handleClass = 'bg-[var(--node-logic)]';
+    return definitions.map((port) => ({
+      id: port.id,
+      label: 'Boolean result',
+      tooltip: 'Result of the boolean operation',
+      handleClassName: 'bg-[var(--node-logic)]',
+    }));
+  }, [nodeDefinition]);
+
+  const operatorLabel = getOperatorLabel(data.operator);
+  const operatorSymbol = getOperatorSymbol(data.operator);
+
+  const formula = data.operator === 'not' ? `${operatorSymbol}A` : `A ${operatorSymbol} B`;
 
   return (
-    <Card selected={selected} className="min-w-[var(--node-min-width)] p-[var(--card-padding)]">
-      {/* Dynamic input ports */}
-      {nodeDefinition?.ports.inputs.map((port, index) => (
-        <Handle
-          key={port.id}
-          type="target"
-          position={Position.Left}
-          id={port.id}
-          className={`h-3 w-3 ${handleClass} !border-2 !border-[var(--text-primary)]`}
-          style={{ top: `${35 + index * 30}%` }}
-        />
-      ))}
-
-      <CardHeader className="p-0 pb-[var(--space-3)]">
-        <div className="flex items-center gap-[var(--space-2)]">
-          <div className="flex h-6 w-6 items-center justify-center rounded bg-[var(--node-logic)] text-[var(--text-primary)]">
-            <Binary size={12} />
-          </div>
-          <span className="font-semibold text-[var(--text-primary)]">
-            {data.identifier.displayName}
-          </span>
-        </div>
-      </CardHeader>
-
-      <CardContent className="space-y-2 p-0">
-        <div className="rounded border border-[var(--border-primary)] bg-[var(--surface-2)] p-2 text-center">
-          <div className="font-mono text-sm text-[var(--text-primary)]">
-            Bool ({getOperatorDisplay()})
-          </div>
-          <div className="mt-1 font-mono text-lg text-[var(--text-primary)]">
-            {data.operator === 'not' ? `${getOperatorSymbol()}A` : `A ${getOperatorSymbol()} B`}
-          </div>
-        </div>
-
-        <div className="flex items-center justify-between">
-          <span className="text-xs text-[var(--text-secondary)]">Operation:</span>
-          <span className="text-xs font-medium text-[var(--text-primary)]">
-            {getOperatorDisplay()}
-          </span>
-        </div>
-
-        <div className="text-center text-xs">
-          <span className="rounded-[var(--radius-sm)] bg-[var(--accent-100)] px-[var(--space-2)] py-[var(--space-1)] text-[var(--accent-900)]">
-            Boolean Logic
-          </span>
-        </div>
-
-        <div className="mt-3 border-t border-[var(--border-primary)] pt-2">
-          <div className="text-center text-xs text-[var(--text-tertiary)]">
-            {data.operator === 'not' ? '1 Input' : '2 Inputs'} → Boolean
-          </div>
-        </div>
-      </CardContent>
-
-      {/* Output port */}
-      {nodeDefinition?.ports.outputs.map((port) => (
-        <Handle
-          key={port.id}
-          type="source"
-          position={Position.Right}
-          id={port.id}
-          className={`h-3 w-3 ${handleClass} !border-2 !border-[var(--text-primary)]`}
-          style={{ top: '50%' }}
-        />
-      ))}
-    </Card>
+    <NodeLayout
+      selected={selected}
+      title={data.identifier.displayName}
+      subtitle={`Boolean ${operatorLabel}`}
+      icon={<Binary size={14} />}
+      iconClassName="bg-[var(--node-logic)]"
+      inputs={inputs}
+      outputs={outputs}
+      measureDeps={[data.operator, inputs.length]}
+    >
+      <div className="rounded border border-[var(--border-primary)] bg-[var(--surface-2)] p-[var(--space-2)] text-center font-mono text-sm text-[var(--text-primary)]">
+        {formula}
+      </div>
+      <div className="text-xs text-[var(--text-secondary)]">Outputs true when the expression evaluates to true.</div>
+    </NodeLayout>
   );
 }

--- a/src/components/workspace/nodes/canvas-node.tsx
+++ b/src/components/workspace/nodes/canvas-node.tsx
@@ -1,11 +1,11 @@
-// src/components/workspace/nodes/canvas-node.tsx
 'use client';
 
-import { Handle, Position, type NodeProps } from 'reactflow';
-import { Card, CardHeader, CardContent } from '@/components/ui/card';
-import { getNodeDefinition } from '@/shared/registry/registry-utils';
-import type { CanvasNodeData } from '@/shared/types/nodes';
+import { useMemo } from 'react';
+import type { NodeProps } from 'reactflow';
 import { Palette } from 'lucide-react';
+import { getNodeDefinition } from '@/shared/registry/registry-utils';
+import { NodeLayout, type PortConfig } from './components/node-layout';
+import type { CanvasNodeData } from '@/shared/types/nodes';
 
 type CanvasNodeProps = NodeProps<CanvasNodeData> & {
   onOpenCanvas?: () => void;
@@ -14,64 +14,76 @@ type CanvasNodeProps = NodeProps<CanvasNodeData> & {
 export function CanvasNode({ data, selected, onOpenCanvas }: CanvasNodeProps) {
   const nodeDefinition = getNodeDefinition('canvas');
 
+  const inputs = useMemo<PortConfig[]>(() => {
+    const definitions = nodeDefinition?.ports.inputs ?? [];
+    if (definitions.length === 0) {
+      return [
+        {
+          id: 'input',
+          label: 'Objects to draw',
+          tooltip: 'Incoming objects placed on this canvas',
+          handleClassName: 'bg-[var(--node-geometry)]',
+        },
+      ];
+    }
+
+    return definitions.map((port) => ({
+      id: port.id,
+      label: 'Objects to draw',
+      tooltip: 'Incoming objects placed on this canvas',
+      handleClassName: 'bg-[var(--node-geometry)]',
+    }));
+  }, [nodeDefinition]);
+
+  const outputs = useMemo<PortConfig[]>(() => {
+    const definitions = nodeDefinition?.ports.outputs ?? [];
+    if (definitions.length === 0) {
+      return [
+        {
+          id: 'output',
+          label: 'Canvas result',
+          tooltip: 'Emits the composed canvas for downstream nodes',
+          handleClassName: 'bg-[var(--node-geometry)]',
+        },
+      ];
+    }
+
+    return definitions.map((port) => ({
+      id: port.id,
+      label: 'Canvas result',
+      tooltip: 'Emits the composed canvas for downstream nodes',
+      handleClassName: 'bg-[var(--node-geometry)]',
+    }));
+  }, [nodeDefinition]);
+
   const handleDoubleClick = () => {
-    if (onOpenCanvas) return onOpenCanvas();
+    if (onOpenCanvas) {
+      onOpenCanvas();
+      return;
+    }
+
     const params = new URLSearchParams(window.location.search);
     const ws = params.get('workspace');
     const url = new URL(window.location.href);
     url.searchParams.set('tab', 'canvas');
-    url.searchParams.set('node', data?.identifier?.id ?? '');
+    url.searchParams.set('node', data.identifier.id);
     if (ws) url.searchParams.set('workspace', ws);
     window.history.pushState({}, '', url.toString());
   };
 
-  const handleClass = 'bg-[var(--node-geometry)]';
-
   return (
-    <Card
+    <NodeLayout
       selected={selected}
-      className="min-w-[var(--node-min-width)] cursor-pointer p-[var(--card-padding)] transition-all hover:bg-[var(--surface-interactive)]"
+      title={data.identifier.displayName}
+      subtitle="Canvas composition"
+      icon={<Palette size={14} />}
+      iconClassName="bg-[var(--node-geometry)]"
+      inputs={inputs}
+      outputs={outputs}
       onDoubleClick={handleDoubleClick}
-    >
-      {nodeDefinition?.ports.inputs.map((port) => (
-        <Handle
-          key={port.id}
-          type="target"
-          position={Position.Left}
-          id={port.id}
-          className={`h-3 w-3 ${handleClass} !border-2 !border-[var(--text-primary)]`}
-          style={{ top: `50%` }}
-        />
-      ))}
-      {nodeDefinition?.ports.outputs.map((port, idx) => (
-        <Handle
-          key={port.id}
-          type="source"
-          position={Position.Right}
-          id={port.id}
-          className={`h-3 w-3 ${handleClass} !border-2 !border-[var(--text-primary)]`}
-          style={{ top: `${50 + idx * 16}%` }}
-        />
-      ))}
-
-      <CardHeader className="p-0 pb-[var(--space-3)]">
-        <div className="flex items-center gap-[var(--space-2)]">
-          <div className="flex h-6 w-6 items-center justify-center rounded bg-[var(--node-geometry)] text-[var(--text-primary)]">
-            <Palette size={12} />
-          </div>
-          <div className="min-w-0 flex-1">
-            <div className="truncate font-semibold text-[var(--text-primary)]">
-              {data?.identifier?.displayName ?? 'Canvas'}
-            </div>
-          </div>
-        </div>
-      </CardHeader>
-
-      <CardContent className="space-y-2 p-0 text-xs text-[var(--text-secondary)]">
-        <div className="pt-1 text-[10px] text-[var(--text-tertiary)]">
-          Double-click to edit in Canvas tab
-        </div>
-      </CardContent>
-    </Card>
+      measureDeps={[]}
+      className="cursor-pointer"
+      footer="Double-click to edit in the Canvas tab"
+    />
   );
 }

--- a/src/components/workspace/nodes/circle-node.tsx
+++ b/src/components/workspace/nodes/circle-node.tsx
@@ -1,46 +1,39 @@
-// src/components/workspace/nodes/circle-node.tsx - Simplified single output port
 'use client';
 
-import { Handle, Position, type NodeProps } from 'reactflow';
-import { Card, CardHeader, CardContent } from '@/components/ui/card';
-import { getNodeDefinition } from '@/shared/registry/registry-utils';
-import type { CircleNodeData } from '@/shared/types/nodes';
+import { useMemo } from 'react';
+import type { NodeProps } from 'reactflow';
 import { Circle as CircleIcon } from 'lucide-react';
+import { NodeLayout, type PortConfig } from './components/node-layout';
+import type { CircleNodeData } from '@/shared/types/nodes';
 
 export function CircleNode({ data, selected }: NodeProps<CircleNodeData>) {
-  const nodeDefinition = getNodeDefinition('circle');
+  const outputs = useMemo<PortConfig[]>(
+    () => [
+      {
+        id: 'output',
+        label: 'Circle object',
+        tooltip: 'Provides the generated circle geometry',
+        handleClassName: 'bg-[var(--node-geometry)]',
+      },
+    ],
+    [],
+  );
 
   return (
-    <Card selected={selected} className="min-w-[var(--node-min-width)] p-[var(--card-padding)]">
-      <CardHeader className="p-0 pb-[var(--space-3)]">
-        <div className="flex items-center gap-[var(--space-2)]">
-          <div
-            className="flex h-6 w-6 items-center justify-center rounded text-[var(--text-primary)]"
-            style={{ backgroundColor: '#4444ff' }} // Canvas default
-          >
-            <CircleIcon size={12} />
-          </div>
-          <span className="font-semibold text-[var(--text-primary)]">
-            {data.identifier.displayName}
-          </span>
-        </div>
-      </CardHeader>
-
-      <CardContent className="space-y-1 p-0 text-xs text-[var(--text-secondary)]">
-        <div>Radius: {data.radius || 50}px</div>
-      </CardContent>
-
-      {/* Single output port */}
-      {nodeDefinition?.ports.outputs.map((port) => (
-        <Handle
-          key={port.id}
-          type="source"
-          position={Position.Right}
-          id={port.id}
-          className={`h-3 w-3 !border-2 !border-[var(--text-primary)] bg-[var(--node-geometry)]`}
-          style={{ top: `50%` }}
-        />
-      ))}
-    </Card>
+    <NodeLayout
+      selected={selected}
+      title={data.identifier.displayName}
+      subtitle="Perfect circle geometry"
+      icon={<CircleIcon size={14} />}
+      iconClassName="bg-[var(--node-geometry)]"
+      inputs={[]}
+      outputs={outputs}
+      measureDeps={[data.radius]}
+    >
+      <div className="flex items-center justify-between">
+        <span>Radius</span>
+        <span className="font-medium text-[var(--text-primary)]">{data.radius}px</span>
+      </div>
+    </NodeLayout>
   );
 }

--- a/src/components/workspace/nodes/compare-node.tsx
+++ b/src/components/workspace/nodes/compare-node.tsx
@@ -1,114 +1,126 @@
-// src/components/workspace/nodes/compare-node.tsx - Compare logic node
 'use client';
 
-import { Handle, Position, type NodeProps } from 'reactflow';
-import { Card, CardHeader, CardContent } from '@/components/ui/card';
-import { getNodeDefinition } from '@/shared/registry/registry-utils';
-import type { CompareNodeData } from '@/shared/types/nodes';
+import { useMemo } from 'react';
+import type { NodeProps } from 'reactflow';
 import { Equal } from 'lucide-react';
+import { getNodeDefinition } from '@/shared/registry/registry-utils';
+import { NodeLayout, type PortConfig } from './components/node-layout';
+import type { CompareNodeData } from '@/shared/types/nodes';
+
+function getOperatorSymbol(operator: CompareNodeData['operator']) {
+  switch (operator) {
+    case 'gt':
+      return '>';
+    case 'lt':
+      return '<';
+    case 'eq':
+      return '==';
+    case 'neq':
+      return '!=';
+    case 'gte':
+      return '>=';
+    case 'lte':
+      return '<=';
+    default:
+      return '?';
+  }
+}
+
+function getOperatorLabel(operator: CompareNodeData['operator']) {
+  switch (operator) {
+    case 'gt':
+      return 'Greater than';
+    case 'lt':
+      return 'Less than';
+    case 'eq':
+      return 'Equal';
+    case 'neq':
+      return 'Not equal';
+    case 'gte':
+      return 'Greater or equal';
+    case 'lte':
+      return 'Less or equal';
+    default:
+      return 'Comparison';
+  }
+}
 
 export function CompareNode({ data, selected }: NodeProps<CompareNodeData>) {
   const nodeDefinition = getNodeDefinition('compare');
 
-  const getOperatorSymbol = () => {
-    switch (data.operator) {
-      case 'gt':
-        return '>';
-      case 'lt':
-        return '<';
-      case 'eq':
-        return '==';
-      case 'neq':
-        return '!=';
-      case 'gte':
-        return '>=';
-      case 'lte':
-        return '<=';
+  const inputs = useMemo<PortConfig[]>(() => {
+    const definitions = nodeDefinition?.ports.inputs ?? [];
+    if (definitions.length === 0) {
+      return [
+        {
+          id: 'input_a',
+          label: 'First value',
+          tooltip: 'Value compared on the left side (A)',
+          handleClassName: 'bg-[var(--node-logic)]',
+          badge: 'A',
+        },
+        {
+          id: 'input_b',
+          label: 'Second value',
+          tooltip: 'Value compared on the right side (B)',
+          handleClassName: 'bg-[var(--node-logic)]',
+          badge: 'B',
+        },
+      ];
     }
-  };
 
-  const getOperatorLabel = () => {
-    switch (data.operator) {
-      case 'gt':
-        return 'Greater than';
-      case 'lt':
-        return 'Less than';
-      case 'eq':
-        return 'Equal';
-      case 'neq':
-        return 'Not equal';
-      case 'gte':
-        return 'Greater or equal';
-      case 'lte':
-        return 'Less or equal';
+    return definitions.map((port, index) => ({
+      id: port.id,
+      label: index === 0 ? 'First value' : 'Second value',
+      tooltip: index === 0
+        ? 'Value compared on the left side (A)'
+        : 'Value compared on the right side (B)',
+      handleClassName: 'bg-[var(--node-logic)]',
+      badge: index === 0 ? 'A' : 'B',
+    }));
+  }, [nodeDefinition]);
+
+  const outputs = useMemo<PortConfig[]>(() => {
+    const definitions = nodeDefinition?.ports.outputs ?? [];
+    if (definitions.length === 0) {
+      return [
+        {
+          id: 'output',
+          label: 'Comparison result',
+          tooltip: 'Boolean result of the configured comparison',
+          handleClassName: 'bg-[var(--node-logic)]',
+        },
+      ];
     }
-  };
 
-  const handleClass = 'bg-[var(--node-logic)]';
+    return definitions.map((port) => ({
+      id: port.id,
+      label: 'Comparison result',
+      tooltip: 'Boolean result of the configured comparison',
+      handleClassName: 'bg-[var(--node-logic)]',
+    }));
+  }, [nodeDefinition]);
+
+  const operatorLabel = getOperatorLabel(data.operator);
+  const operatorSymbol = getOperatorSymbol(data.operator);
 
   return (
-    <Card selected={selected} className="min-w-[var(--node-min-width)] p-[var(--card-padding)]">
-      {/* Input ports */}
-      {nodeDefinition?.ports.inputs.map((port, index) => (
-        <Handle
-          key={port.id}
-          type="target"
-          position={Position.Left}
-          id={port.id}
-          className={`h-3 w-3 ${handleClass} !border-2 !border-[var(--text-primary)]`}
-          style={{ top: `${35 + index * 30}%` }}
-        />
-      ))}
-
-      <CardHeader className="p-0 pb-[var(--space-3)]">
-        <div className="flex items-center gap-[var(--space-2)]">
-          <div className="flex h-6 w-6 items-center justify-center rounded bg-[var(--node-logic)] text-[var(--text-primary)]">
-            <Equal size={12} />
-          </div>
-          <span className="font-semibold text-[var(--text-primary)]">
-            {data.identifier.displayName}
-          </span>
-        </div>
-      </CardHeader>
-
-      <CardContent className="space-y-2 p-0">
-        <div className="rounded border border-[var(--border-primary)] bg-[var(--surface-2)] p-2 text-center">
-          <div className="font-mono text-lg text-[var(--text-primary)]">
-            A {getOperatorSymbol()} B
-          </div>
-        </div>
-
-        <div className="flex items-center justify-between">
-          <span className="text-xs text-[var(--text-secondary)]">Operation:</span>
-          <span className="text-xs font-medium text-[var(--text-primary)]">
-            {getOperatorLabel()}
-          </span>
-        </div>
-
-        <div className="text-center text-xs">
-          <span className="rounded-[var(--radius-sm)] bg-[var(--success-100)] px-[var(--space-2)] py-[var(--space-1)] text-[var(--success-700)]">
-            Boolean Output
-          </span>
-        </div>
-
-        <div className="mt-3 border-t border-[var(--border-primary)] pt-2">
-          <div className="text-center text-xs text-[var(--text-tertiary)]">
-            Type-Safe Comparison
-          </div>
-        </div>
-      </CardContent>
-
-      {/* Output port */}
-      {nodeDefinition?.ports.outputs.map((port) => (
-        <Handle
-          key={port.id}
-          type="source"
-          position={Position.Right}
-          id={port.id}
-          className={`h-3 w-3 ${handleClass} !border-2 !border-[var(--text-primary)]`}
-          style={{ top: '50%' }}
-        />
-      ))}
-    </Card>
+    <NodeLayout
+      selected={selected}
+      title={data.identifier.displayName}
+      subtitle={`${operatorLabel}`}
+      icon={<Equal size={14} />}
+      iconClassName="bg-[var(--node-logic)]"
+      inputs={inputs}
+      outputs={outputs}
+      measureDeps={[data.operator]}
+    >
+      <div className="rounded border border-[var(--border-primary)] bg-[var(--surface-2)] p-[var(--space-2)] text-center font-mono text-sm text-[var(--text-primary)]">
+        A {operatorSymbol} B
+      </div>
+      <div className="text-xs text-[var(--text-secondary)]">
+        Emits <span className="font-medium text-[var(--text-primary)]">true</span> when the comparison holds.
+      </div>
+    </NodeLayout>
   );
 }

--- a/src/components/workspace/nodes/components/node-layout.tsx
+++ b/src/components/workspace/nodes/components/node-layout.tsx
@@ -1,0 +1,424 @@
+'use client';
+
+import {
+  useCallback,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type HTMLAttributes,
+  type ReactNode,
+} from 'react';
+import { Handle, Position } from 'reactflow';
+import { Card } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+
+const PORT_ZONE_MIN_WIDTH = 64;
+const PORT_ZONE_MAX_WIDTH = 168;
+const PORT_ZONE_PADDING = 12;
+const HANDLE_BASE_CLASS = 'h-3 w-3 !border-2 !border-[var(--text-primary)]';
+const TITLE_LINE_CLAMP_STYLE: CSSProperties = {
+  display: '-webkit-box',
+  WebkitBoxOrient: 'vertical',
+  WebkitLineClamp: 2,
+  overflow: 'hidden',
+};
+
+export interface PortConfig {
+  id: string;
+  label: string;
+  handleClassName: string;
+  tooltip?: string;
+  badge?: string;
+  icon?: ReactNode;
+  badgeClassName?: string;
+  labelClassName?: string;
+  handleProps?: HTMLAttributes<HTMLDivElement>;
+}
+
+interface NodeLayoutProps {
+  selected: boolean;
+  title: string;
+  subtitle?: string;
+  icon: ReactNode;
+  iconClassName: string;
+  inputs: PortConfig[];
+  outputs: PortConfig[];
+  children?: ReactNode;
+  footer?: ReactNode;
+  onDoubleClick?: () => void;
+  className?: string;
+  headerAccessory?: ReactNode;
+  measureDeps?: Array<string | number | boolean | null | undefined>;
+}
+
+interface PortBadgeProps {
+  side: 'input' | 'output';
+  config: PortConfig;
+  onRef: (element: HTMLDivElement | null) => void;
+}
+
+const lineClampStyle: CSSProperties = {
+  display: '-webkit-box',
+  WebkitBoxOrient: 'vertical',
+  WebkitLineClamp: 2,
+  overflow: 'hidden',
+};
+
+function PortBadge({ side, config, onRef }: PortBadgeProps) {
+  const { badge, icon, label, tooltip, badgeClassName, labelClassName } = config;
+  const displayBadge = icon ?? badge;
+  const shouldRenderBadge = displayBadge !== undefined && displayBadge !== null && displayBadge !== '';
+  return (
+    <div
+      ref={onRef}
+      className={cn(
+        'flex min-h-[26px] min-w-0 max-w-full items-center gap-[var(--space-1)] rounded-[var(--radius-sm)] bg-[var(--surface-2)] px-[var(--space-2)] py-[var(--space-1)] text-xs text-[var(--text-primary)] shadow-[0_0_0_1px_rgba(255,255,255,0.08)] backdrop-blur-[2px]',
+        side === 'input' ? 'justify-end text-right' : 'justify-start text-left',
+        badgeClassName,
+      )}
+      title={tooltip ?? label}
+    >
+      {shouldRenderBadge && (
+        <span
+          className={cn(
+            'flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-[var(--surface-3)] text-[10px] font-medium text-[var(--text-tertiary)]',
+            side === 'input' ? 'order-first' : 'order-none',
+          )}
+        >
+          {displayBadge}
+        </span>
+      )}
+      <span
+        className={cn(
+          'max-w-full text-xs leading-snug text-[var(--text-primary)]',
+          side === 'input' ? 'text-right' : 'text-left',
+          labelClassName,
+        )}
+        style={lineClampStyle}
+      >
+        {label}
+      </span>
+    </div>
+  );
+}
+
+interface LayoutState {
+  leftWidth: number;
+  rightWidth: number;
+  leftPositions: number[];
+  rightPositions: number[];
+}
+
+const INITIAL_LAYOUT: LayoutState = {
+  leftWidth: 0,
+  rightWidth: 0,
+  leftPositions: [],
+  rightPositions: [],
+};
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function arraysClose(a: number[], b: number[], epsilon = 0.5) {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (Math.abs(a[i] - b[i]) > epsilon) return false;
+  }
+  return true;
+}
+
+export function NodeLayout({
+  selected,
+  title,
+  subtitle,
+  icon,
+  iconClassName,
+  inputs,
+  outputs,
+  children,
+  footer,
+  onDoubleClick,
+  className,
+  headerAccessory,
+  measureDeps,
+}: NodeLayoutProps) {
+  const cardRef = useRef<HTMLDivElement | null>(null);
+  const leftBadgeRefs = useRef<Record<string, HTMLDivElement | null>>({});
+  const rightBadgeRefs = useRef<Record<string, HTMLDivElement | null>>({});
+  const leftRowRefs = useRef<Record<string, HTMLDivElement | null>>({});
+  const rightRowRefs = useRef<Record<string, HTMLDivElement | null>>({});
+  const [layout, setLayout] = useState<LayoutState>(INITIAL_LAYOUT);
+
+  const hasInputs = inputs.length > 0;
+  const hasOutputs = outputs.length > 0;
+
+  const measureKey = useMemo(() => {
+    if (!measureDeps || measureDeps.length === 0) return '';
+    return measureDeps.map((value) => `${value ?? ''}`).join('|');
+  }, [measureDeps]);
+
+  const inputSignature = useMemo(
+    () => inputs.map((port) => `${port.id}:${port.label}`).join('|'),
+    [inputs],
+  );
+
+  const outputSignature = useMemo(
+    () => outputs.map((port) => `${port.id}:${port.label}`).join('|'),
+    [outputs],
+  );
+
+  const updateLayout = useCallback(() => {
+    const card = cardRef.current;
+    if (!card) return;
+
+    const cardRect = card.getBoundingClientRect();
+
+    let maxLeftWidth = 0;
+    let maxRightWidth = 0;
+
+    for (const port of inputs) {
+      const badge = leftBadgeRefs.current[port.id];
+      if (badge) {
+        const width = badge.scrollWidth;
+        if (width > maxLeftWidth) maxLeftWidth = width;
+      }
+    }
+
+    for (const port of outputs) {
+      const badge = rightBadgeRefs.current[port.id];
+      if (badge) {
+        const width = badge.scrollWidth;
+        if (width > maxRightWidth) maxRightWidth = width;
+      }
+    }
+
+    const leftWidth = hasInputs
+      ? clamp(Math.ceil(maxLeftWidth) + PORT_ZONE_PADDING, PORT_ZONE_MIN_WIDTH, PORT_ZONE_MAX_WIDTH)
+      : 0;
+    const rightWidth = hasOutputs
+      ? clamp(Math.ceil(maxRightWidth) + PORT_ZONE_PADDING, PORT_ZONE_MIN_WIDTH, PORT_ZONE_MAX_WIDTH)
+      : 0;
+
+    const leftPositions = inputs.map((port) => {
+      const row = leftRowRefs.current[port.id];
+      if (!row) return cardRect.height / 2;
+      const rect = row.getBoundingClientRect();
+      return rect.top - cardRect.top + rect.height / 2;
+    });
+
+    const rightPositions = outputs.map((port) => {
+      const row = rightRowRefs.current[port.id];
+      if (!row) return cardRect.height / 2;
+      const rect = row.getBoundingClientRect();
+      return rect.top - cardRect.top + rect.height / 2;
+    });
+
+    setLayout((prev) => {
+      if (
+        prev.leftWidth === leftWidth &&
+        prev.rightWidth === rightWidth &&
+        arraysClose(prev.leftPositions, leftPositions) &&
+        arraysClose(prev.rightPositions, rightPositions)
+      ) {
+        return prev;
+      }
+      return {
+        leftWidth,
+        rightWidth,
+        leftPositions,
+        rightPositions,
+      };
+    });
+  }, [hasInputs, hasOutputs, inputs, outputs]);
+
+  useLayoutEffect(() => {
+    let frame: number | null = null;
+    const runMeasure = () => {
+      if (frame) cancelAnimationFrame(frame);
+      frame = requestAnimationFrame(() => {
+        updateLayout();
+        frame = null;
+      });
+    };
+
+    runMeasure();
+
+    if (cardRef.current && 'ResizeObserver' in window) {
+      const observer = new ResizeObserver(() => {
+        runMeasure();
+      });
+      observer.observe(cardRef.current);
+      return () => {
+        observer.disconnect();
+        if (frame) cancelAnimationFrame(frame);
+      };
+    }
+
+    return () => {
+      if (frame) cancelAnimationFrame(frame);
+    };
+  }, [updateLayout, inputSignature, outputSignature, measureKey, subtitle]);
+
+  const gridTemplateColumns = useMemo(() => {
+    const columns: string[] = [];
+    if (hasInputs) columns.push(`${Math.max(layout.leftWidth, PORT_ZONE_MIN_WIDTH)}px`);
+    columns.push('minmax(0, 1fr)');
+    if (hasOutputs) columns.push(`${Math.max(layout.rightWidth, PORT_ZONE_MIN_WIDTH)}px`);
+    return columns.join(' ');
+  }, [hasInputs, hasOutputs, layout.leftWidth, layout.rightWidth]);
+
+  const handleLeftTop = (index: number) => {
+    if (!hasInputs || !layout.leftPositions.length) return '50%';
+    return `${layout.leftPositions[index]}px`;
+  };
+
+  const handleRightTop = (index: number) => {
+    if (!hasOutputs || !layout.rightPositions.length) return '50%';
+    return `${layout.rightPositions[index]}px`;
+  };
+
+  return (
+    <Card
+      ref={cardRef}
+      selected={selected}
+      onDoubleClick={onDoubleClick}
+      className={cn('min-w-[var(--node-min-width)] p-[var(--card-padding)]', className)}
+    >
+      {hasInputs &&
+        inputs.map((port, index) => (
+          <Handle
+            key={port.id}
+            type="target"
+            position={Position.Left}
+            id={port.id}
+            className={cn(HANDLE_BASE_CLASS, port.handleClassName)}
+            style={{ top: handleLeftTop(index), transform: 'translateY(-50%)' }}
+            {...port.handleProps}
+          />
+        ))}
+
+      {hasOutputs &&
+        outputs.map((port, index) => (
+          <Handle
+            key={port.id}
+            type="source"
+            position={Position.Right}
+            id={port.id}
+            className={cn(HANDLE_BASE_CLASS, port.handleClassName)}
+            style={{ top: handleRightTop(index), transform: 'translateY(-50%)' }}
+            {...port.handleProps}
+          />
+        ))}
+
+      <div
+        className="grid items-stretch gap-x-[var(--space-3)]"
+        style={{ gridTemplateColumns }}
+      >
+        {hasInputs && (
+          <div className="flex h-full min-h-[80px] flex-col justify-evenly gap-[var(--space-2)] pr-[var(--space-1)]">
+            {inputs.map((port) => (
+              <div
+                key={port.id}
+                ref={(element) => {
+                  if (element) {
+                    leftRowRefs.current[port.id] = element;
+                  } else {
+                    delete leftRowRefs.current[port.id];
+                  }
+                }}
+                className="flex w-full justify-end"
+              >
+                <PortBadge
+                  side="input"
+                  config={port}
+                  onRef={(element) => {
+                    if (element) {
+                      leftBadgeRefs.current[port.id] = element;
+                    } else {
+                      delete leftBadgeRefs.current[port.id];
+                    }
+                  }}
+                />
+              </div>
+            ))}
+          </div>
+        )}
+
+        <div className="flex min-h-[96px] flex-col gap-[var(--space-3)]">
+          <div className="flex flex-col gap-[var(--space-2)]">
+            <div className="flex items-start justify-between gap-[var(--space-3)]">
+              <div className="flex min-w-0 items-start gap-[var(--space-2)]">
+                <div
+                  className={cn(
+                    'flex h-8 w-8 shrink-0 items-center justify-center rounded-[var(--radius-sm)] text-[var(--text-primary)]',
+                    iconClassName,
+                  )}
+                >
+                  {icon}
+                </div>
+                <div className="min-w-0">
+                  <div className="truncate text-sm font-semibold text-[var(--text-primary)]" title={title}>
+                    {title}
+                  </div>
+                  {subtitle ? (
+                    <div
+                      className="mt-[2px] text-xs text-[var(--text-secondary)]"
+                      style={TITLE_LINE_CLAMP_STYLE}
+                      title={subtitle}
+                    >
+                      {subtitle}
+                    </div>
+                  ) : null}
+                </div>
+              </div>
+              {headerAccessory ? (
+                <div className="shrink-0 text-xs text-[var(--text-tertiary)]">{headerAccessory}</div>
+              ) : null}
+            </div>
+          </div>
+
+          {children ? (
+            <div className="flex flex-col gap-[var(--space-2)] text-xs text-[var(--text-secondary)]">
+              {children}
+            </div>
+          ) : null}
+
+          {footer ? <div className="mt-auto text-xs text-[var(--text-tertiary)]">{footer}</div> : null}
+        </div>
+
+        {hasOutputs && (
+          <div className="flex h-full min-h-[80px] flex-col justify-evenly gap-[var(--space-2)] pl-[var(--space-1)]">
+            {outputs.map((port) => (
+              <div
+                key={port.id}
+                ref={(element) => {
+                  if (element) {
+                    rightRowRefs.current[port.id] = element;
+                  } else {
+                    delete rightRowRefs.current[port.id];
+                  }
+                }}
+                className="flex w-full justify-start"
+              >
+                <PortBadge
+                  side="output"
+                  config={port}
+                  onRef={(element) => {
+                    if (element) {
+                      rightBadgeRefs.current[port.id] = element;
+                    } else {
+                      delete rightBadgeRefs.current[port.id];
+                    }
+                  }}
+                />
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+}

--- a/src/components/workspace/nodes/constants-node.tsx
+++ b/src/components/workspace/nodes/constants-node.tsx
@@ -1,114 +1,62 @@
-// src/components/workspace/nodes/constants-node.tsx - Constants value output node
 'use client';
 
-import { Handle, Position, type NodeProps } from 'reactflow';
-import { Card, CardHeader, CardContent } from '@/components/ui/card';
-import { getNodeDefinition } from '@/shared/registry/registry-utils';
+import { useMemo } from 'react';
+import type { NodeProps } from 'reactflow';
+import { Palette } from 'lucide-react';
+import { NodeLayout, type PortConfig } from './components/node-layout';
 import type { ConstantsNodeData } from '@/shared/types/nodes';
 
+function formatValue(data: ConstantsNodeData) {
+  switch (data.valueType) {
+    case 'number':
+      return String(data.numberValue);
+    case 'string':
+      return data.stringValue.length > 30 ? `${data.stringValue.slice(0, 27)}…` : data.stringValue;
+    case 'boolean':
+      return data.booleanValue === 'true' ? 'true' : 'false';
+    case 'color':
+      return data.colorValue.toUpperCase();
+    default:
+      return '—';
+  }
+}
+
 export function ConstantsNode({ data, selected }: NodeProps<ConstantsNodeData>) {
-  const nodeDefinition = getNodeDefinition('constants');
+  const outputs = useMemo<PortConfig[]>(
+    () => [
+      {
+        id: 'output',
+        label: 'Constant value',
+        tooltip: 'Emits the configured constant for downstream nodes',
+        handleClassName: 'bg-[var(--node-data)]',
+      },
+    ],
+    [],
+  );
 
-  // Get current value based on type
-  const getCurrentValue = () => {
-    switch (data.valueType) {
-      case 'number':
-        return data.numberValue;
-      case 'string':
-        return `"${data.stringValue}"`;
-      case 'boolean':
-        return data.booleanValue === 'true' ? 'true' : 'false';
-      case 'color':
-        return data.colorValue.toUpperCase();
-      default:
-        return 'Unknown';
-    }
-  };
-
-  const getValueDisplay = () => {
-    const value = getCurrentValue();
-    const maxLength = 12;
-    const valueStr = String(value);
-
-    if (valueStr.length > maxLength) {
-      return valueStr.substring(0, maxLength - 3) + '...';
-    }
-    return valueStr;
-  };
-
-  const getTypeIcon = () => {
-    switch (data.valueType) {
-      case 'number':
-        return '🔢';
-      case 'string':
-        return '📝';
-      case 'boolean':
-        return '✓';
-      case 'color':
-        return '🎨';
-      default:
-        return '🔢';
-    }
-  };
-
-  const handleClass = 'bg-[var(--node-data)]';
+  const displayValue = formatValue(data);
 
   return (
-    <Card selected={selected} className="min-w-[var(--node-min-width)] p-[var(--card-padding)]">
-      <CardHeader className="p-0 pb-[var(--space-3)]">
+    <NodeLayout
+      selected={selected}
+      title={data.identifier.displayName}
+      subtitle={`Outputs a ${data.valueType}`}
+      icon={<Palette size={14} />}
+      iconClassName="bg-[var(--node-data)]"
+      inputs={[]}
+      outputs={outputs}
+      measureDeps={[data.valueType, displayValue]}
+    >
+      <div className="flex items-center justify-between">
+        <span>Current value</span>
+        <span className="font-mono text-sm text-[var(--text-primary)]">{displayValue}</span>
+      </div>
+      {data.valueType === 'color' ? (
         <div className="flex items-center gap-[var(--space-2)]">
-          <div className="flex h-6 w-6 items-center justify-center rounded bg-[var(--node-data)] text-sm font-bold text-[var(--text-primary)]">
-            {getTypeIcon()}
-          </div>
-          <span className="font-semibold text-[var(--text-primary)]">
-            {data.identifier.displayName}
-          </span>
+          <span className="h-4 w-4 rounded border border-[var(--border-primary)]" style={{ backgroundColor: data.colorValue }} />
+          <span className="text-xs text-[var(--text-secondary)]">Preview swatch</span>
         </div>
-      </CardHeader>
-
-      <CardContent className="space-y-[var(--space-2)] p-0">
-        <div className="flex items-center justify-between">
-          <span className="text-xs text-[var(--text-secondary)]">Type:</span>
-          <span className="text-xs font-medium text-[var(--text-primary)] capitalize">
-            {data.valueType}
-          </span>
-        </div>
-
-        <div className="rounded border border-[var(--border-primary)] bg-[var(--surface-2)] p-[var(--space-2)]">
-          <div className="mb-[var(--space-1)] text-xs text-[var(--text-tertiary)]">
-            Current Value:
-          </div>
-          <div className="font-mono text-sm text-[var(--text-primary)]">{getValueDisplay()}</div>
-        </div>
-
-        {data.valueType === 'color' && (
-          <div className="flex items-center gap-[var(--space-2)]">
-            <div
-              className="h-4 w-4 rounded border border-[var(--border-primary)]"
-              style={{ backgroundColor: data.colorValue }}
-            />
-            <span className="text-xs text-[var(--text-secondary)]">Preview</span>
-          </div>
-        )}
-
-        <div className="mt-[var(--space-3)] border-t border-[var(--border-primary)] pt-[var(--space-2)]">
-          <div className="text-center text-xs text-[var(--text-tertiary)]">
-            Constant Value Output
-          </div>
-        </div>
-      </CardContent>
-
-      {/* Single output port */}
-      {nodeDefinition?.ports.outputs.map((port) => (
-        <Handle
-          key={port.id}
-          type="source"
-          position={Position.Right}
-          id={port.id}
-          className={`h-3 w-3 ${handleClass} !border-2 !border-[var(--text-primary)]`}
-          style={{ top: `50%` }}
-        />
-      ))}
-    </Card>
+      ) : null}
+    </NodeLayout>
   );
 }

--- a/src/components/workspace/nodes/filter-node.tsx
+++ b/src/components/workspace/nodes/filter-node.tsx
@@ -1,71 +1,57 @@
-// src/components/workspace/nodes/filter-node.tsx - Confirmed single input/output ports
 'use client';
 
-import { Handle, Position, type NodeProps } from 'reactflow';
-import { Card, CardHeader, CardContent } from '@/components/ui/card';
-import { getNodeDefinition } from '@/shared/registry/registry-utils';
-import type { FilterNodeData } from '@/shared/types/nodes';
+import { useMemo } from 'react';
+import type { NodeProps } from 'reactflow';
 import { Filter } from 'lucide-react';
+import { NodeLayout, type PortConfig } from './components/node-layout';
+import type { FilterNodeData } from '@/shared/types/nodes';
 
 export function FilterNode({ data, selected }: NodeProps<FilterNodeData>) {
-  const nodeDefinition = getNodeDefinition('filter');
+  const selectedCount = data.selectedObjectIds?.length ?? 0;
 
-  const selectedCount = data.selectedObjectIds?.length || 0;
-  const hasSelection = selectedCount > 0;
+  const inputs = useMemo<PortConfig[]>(
+    () => [
+      {
+        id: 'input',
+        label: 'Objects to filter',
+        tooltip: 'Incoming object stream before filtering',
+        handleClassName: 'bg-[var(--node-logic)]',
+      },
+    ],
+    [],
+  );
 
-  const handleClass = 'bg-[var(--node-logic)]';
+  const outputs = useMemo<PortConfig[]>(
+    () => [
+      {
+        id: 'output',
+        label: 'Filtered objects',
+        tooltip: 'Only the selected objects continue downstream',
+        handleClassName: 'bg-[var(--node-logic)]',
+      },
+    ],
+    [],
+  );
 
   return (
-    <Card selected={selected} className="min-w-[var(--node-min-width)] p-[var(--card-padding)]">
-      {/* Single input port */}
-      {nodeDefinition?.ports.inputs.map((port) => (
-        <Handle
-          key={port.id}
-          type="target"
-          position={Position.Left}
-          id={port.id}
-          className={`h-3 w-3 ${handleClass} !border-2 !border-[var(--text-primary)]`}
-          style={{ top: `50%` }}
-        />
-      ))}
-
-      <CardHeader className="p-0 pb-[var(--space-3)]">
-        <div className="flex items-center gap-[var(--space-2)]">
-          <div className="flex h-6 w-6 items-center justify-center rounded bg-[var(--node-logic)] text-[var(--text-primary)]">
-            <Filter size={12} />
-          </div>
-          <span className="font-semibold text-[var(--text-primary)]">
-            {data.identifier.displayName}
-          </span>
+    <NodeLayout
+      selected={selected}
+      title={data.identifier.displayName}
+      subtitle="Pass through selected objects"
+      icon={<Filter size={14} />}
+      iconClassName="bg-[var(--node-logic)]"
+      inputs={inputs}
+      outputs={outputs}
+      measureDeps={[selectedCount]}
+    >
+      {selectedCount > 0 ? (
+        <div className="flex items-center justify-between text-xs">
+          <span>Selected objects</span>
+          <span className="font-medium text-[var(--text-primary)]">{selectedCount}</span>
         </div>
-      </CardHeader>
-
-      <CardContent className="space-y-2 p-0">
-        <div className="flex items-center justify-between">
-          <span className="text-xs text-[var(--text-secondary)]">Selected:</span>
-          <span className="text-xs font-medium text-[var(--text-primary)]">{selectedCount}</span>
-        </div>
-
-        {hasSelection ? (
-          <div className="text-xs text-[var(--success-500)]">
-            {selectedCount} object{selectedCount !== 1 ? 's' : ''} passing through
-          </div>
-        ) : (
-          <div className="text-xs text-[var(--warning-600)]">No objects selected</div>
-        )}
-      </CardContent>
-
-      {/* Single output port */}
-      {nodeDefinition?.ports.outputs.map((port) => (
-        <Handle
-          key={port.id}
-          type="source"
-          position={Position.Right}
-          id={port.id}
-          className={`h-3 w-3 ${handleClass} !border-2 !border-[var(--text-primary)]`}
-          style={{ top: `50%` }}
-        />
-      ))}
-    </Card>
+      ) : (
+        <div className="text-xs text-[var(--text-secondary)]">No filters applied</div>
+      )}
+    </NodeLayout>
   );
 }

--- a/src/components/workspace/nodes/if-else-node.tsx
+++ b/src/components/workspace/nodes/if-else-node.tsx
@@ -1,86 +1,64 @@
-// src/components/workspace/nodes/if-else-node.tsx - If/Else logic node
 'use client';
 
-import { Handle, Position, type NodeProps } from 'reactflow';
-import { Card, CardHeader, CardContent } from '@/components/ui/card';
-
-import type { IfElseNodeData } from '@/shared/types/nodes';
+import { useMemo } from 'react';
+import type { NodeProps } from 'reactflow';
 import { GitBranch } from 'lucide-react';
+import { NodeLayout, type PortConfig } from './components/node-layout';
+import type { IfElseNodeData } from '@/shared/types/nodes';
 
 export function IfElseNode({ data, selected }: NodeProps<IfElseNodeData>) {
-  const handleClass = 'bg-[var(--node-logic)]';
+  const inputs = useMemo<PortConfig[]>(
+    () => [
+      {
+        id: 'condition',
+        label: 'Condition flag',
+        tooltip: 'Boolean value that decides the route',
+        handleClassName: 'bg-[var(--node-logic)]',
+      },
+      {
+        id: 'data',
+        label: 'Data to route',
+        tooltip: 'Payload that will be sent to the true or false path',
+        handleClassName: 'bg-[var(--node-logic)]',
+      },
+    ],
+    [],
+  );
+
+  const outputs = useMemo<PortConfig[]>(
+    () => [
+      {
+        id: 'true_path',
+        label: 'When true',
+        tooltip: 'Data forwarded when the condition is true',
+        handleClassName: 'bg-[var(--success-500)]',
+        labelClassName: 'text-[var(--success-500)]',
+      },
+      {
+        id: 'false_path',
+        label: 'When false',
+        tooltip: 'Data forwarded when the condition is false',
+        handleClassName: 'bg-[var(--danger-500)]',
+        labelClassName: 'text-[var(--danger-500)]',
+      },
+    ],
+    [],
+  );
 
   return (
-    <Card selected={selected} className="min-w-[var(--node-min-width)] p-[var(--card-padding)]">
-      {/* Condition input port */}
-      <Handle
-        type="target"
-        position={Position.Left}
-        id="condition"
-        className={`h-3 w-3 ${handleClass} !border-2 !border-[var(--text-primary)]`}
-        style={{ top: '35%' }}
-      />
-
-      {/* Data input port */}
-      <Handle
-        type="target"
-        position={Position.Left}
-        id="data"
-        className={`h-3 w-3 ${handleClass} !border-2 !border-[var(--text-primary)]`}
-        style={{ top: '65%' }}
-      />
-
-      <CardHeader className="p-0 pb-[var(--space-3)]">
-        <div className="flex items-center gap-[var(--space-2)]">
-          <div className="flex h-6 w-6 items-center justify-center rounded bg-[var(--node-logic)] text-[var(--text-primary)]">
-            <GitBranch size={12} />
-          </div>
-          <span className="font-semibold text-[var(--text-primary)]">
-            {data.identifier.displayName}
-          </span>
-        </div>
-      </CardHeader>
-
-      <CardContent className="space-y-2 p-0">
-        <div className="rounded border border-[var(--border-primary)] bg-[var(--surface-2)] p-2 text-center">
-          <div className="text-sm text-[var(--text-primary)]">
-            if condition → route data to true / else → false
-          </div>
-        </div>
-
-        <div className="grid grid-cols-2 gap-1 text-xs">
-          <div className="text-center text-[var(--success-500)]">True</div>
-          <div className="text-center text-[var(--danger-500)]">False</div>
-        </div>
-
-        <div className="text-center text-xs">
-          <span className="rounded-[var(--radius-sm)] bg-[var(--accent-100)] px-[var(--space-2)] py-[var(--space-1)] text-[var(--accent-900)]">
-            Data Router
-          </span>
-        </div>
-
-        <div className="mt-3 border-t border-[var(--border-primary)] pt-2">
-          <div className="text-center text-xs text-[var(--text-tertiary)]">
-            Condition + Data → Routed Data
-          </div>
-        </div>
-      </CardContent>
-
-      {/* Output ports */}
-      <Handle
-        type="source"
-        position={Position.Right}
-        id="true_path"
-        className={`h-3 w-3 !border-2 !border-[var(--text-primary)] bg-[var(--success-500)]`}
-        style={{ top: '35%' }}
-      />
-      <Handle
-        type="source"
-        position={Position.Right}
-        id="false_path"
-        className={`h-3 w-3 !border-2 !border-[var(--text-primary)] bg-[var(--danger-500)]`}
-        style={{ top: '65%' }}
-      />
-    </Card>
+    <NodeLayout
+      selected={selected}
+      title={data.identifier.displayName}
+      subtitle="Route data based on the condition"
+      icon={<GitBranch size={14} />}
+      iconClassName="bg-[var(--node-logic)]"
+      inputs={inputs}
+      outputs={outputs}
+      measureDeps={[]}
+    >
+      <div className="rounded border border-[var(--border-primary)] bg-[var(--surface-2)] p-[var(--space-2)] text-center text-xs text-[var(--text-secondary)]">
+        Sends the payload to the matching path without modifying it.
+      </div>
+    </NodeLayout>
   );
 }

--- a/src/components/workspace/nodes/image-node.tsx
+++ b/src/components/workspace/nodes/image-node.tsx
@@ -1,41 +1,47 @@
 'use client';
 
-import { Handle, Position, type NodeProps } from 'reactflow';
-import { Card, CardHeader, CardContent } from '@/components/ui/card';
-import { getNodeDefinition } from '@/shared/registry/registry-utils';
-import type { ImageNodeData } from '@/shared/types/nodes';
+import { useMemo } from 'react';
+import type { NodeProps } from 'reactflow';
 import { Image } from 'lucide-react';
+import { getNodeDefinition } from '@/shared/registry/registry-utils';
+import { NodeLayout, type PortConfig } from './components/node-layout';
+import type { ImageNodeData } from '@/shared/types/nodes';
 
 export function ImageNode({ data, selected }: NodeProps<ImageNodeData>) {
   const nodeDefinition = getNodeDefinition('image');
 
+  const outputs = useMemo<PortConfig[]>(() => {
+    const definitions = nodeDefinition?.ports.outputs ?? [];
+    if (definitions.length === 0) {
+      return [
+        {
+          id: 'output',
+          label: 'Image stream',
+          tooltip: 'Provides image assets to downstream nodes',
+          handleClassName: 'bg-[var(--node-input)]',
+        },
+      ];
+    }
+
+    return definitions.map((port) => ({
+      id: port.id,
+      label: 'Image stream',
+      tooltip: 'Provides image assets to downstream nodes',
+      handleClassName: 'bg-[var(--node-input)]',
+    }));
+  }, [nodeDefinition]);
+
   return (
-    <Card selected={selected} className="min-w-[var(--node-min-width)] p-[var(--card-padding)]">
-      <CardHeader className="p-0 pb-[var(--space-3)]">
-        <div className="flex items-center gap-[var(--space-2)]">
-          <div className="flex h-6 w-6 items-center justify-center rounded bg-[var(--node-input)] text-[var(--text-primary)]">
-            <Image size={12} aria-label="Image node icon" />
-          </div>
-          <span className="font-semibold text-[var(--text-primary)]">
-            {data.identifier.displayName}
-          </span>
-        </div>
-      </CardHeader>
-
-      <CardContent className="space-y-1 p-0 text-xs text-[var(--text-secondary)]">
-        <div className="text-[var(--text-tertiary)]">Connect to Media node for editing</div>
-      </CardContent>
-
-      {nodeDefinition?.ports.outputs.map((port) => (
-        <Handle
-          key={port.id}
-          type="source"
-          position={Position.Right}
-          id={port.id}
-          className="h-3 w-3 !border-2 !border-[var(--text-primary)] bg-[var(--node-input)]"
-          style={{ top: '50%' }}
-        />
-      ))}
-    </Card>
+    <NodeLayout
+      selected={selected}
+      title={data.identifier.displayName}
+      subtitle="Imported image asset"
+      icon={<Image size={14} aria-label="Image node icon" />}
+      iconClassName="bg-[var(--node-input)]"
+      inputs={[]}
+      outputs={outputs}
+    >
+      <div className="text-xs text-[var(--text-secondary)]">Connect to a Media node to edit this image.</div>
+    </NodeLayout>
   );
 }

--- a/src/components/workspace/nodes/insert-node.tsx
+++ b/src/components/workspace/nodes/insert-node.tsx
@@ -1,69 +1,69 @@
-// src/components/workspace/nodes/insert-node.tsx - Simplified single input/output ports
 'use client';
 
-import { Handle, Position, type NodeProps } from 'reactflow';
-import { Card, CardHeader, CardContent } from '@/components/ui/card';
-import { getNodeDefinition } from '@/shared/registry/registry-utils';
-import type { InsertNodeData } from '@/shared/types/nodes';
-import React from 'react';
+import { useMemo, useState } from 'react';
+import type { NodeProps } from 'reactflow';
+import { Clock3 } from 'lucide-react';
+import { NodeLayout, type PortConfig } from './components/node-layout';
 import { InsertModal } from './InsertModal';
+import type { InsertNodeData } from '@/shared/types/nodes';
 
 export function InsertNode({ data, selected }: NodeProps<InsertNodeData>) {
-  const nodeDefinition = getNodeDefinition('insert');
-  const [open, setOpen] = React.useState(false);
+  const [open, setOpen] = useState(false);
 
-  const handleClass = 'bg-[var(--node-data)]';
+  const inputs = useMemo<PortConfig[]>(
+    () => [
+      {
+        id: 'input',
+        label: 'Object to schedule',
+        tooltip: 'Receives the object stream that should be timed',
+        handleClassName: 'bg-[var(--node-data)]',
+      },
+    ],
+    [],
+  );
+
+  const outputs = useMemo<PortConfig[]>(
+    () => [
+      {
+        id: 'output',
+        label: 'Timed object stream',
+        tooltip: 'Emits objects with the configured appearance time',
+        handleClassName: 'bg-[var(--node-data)]',
+      },
+    ],
+    [],
+  );
+
+  const customAssignments = Object.keys(data.appearanceTimeByObject ?? {}).length;
 
   return (
-    <Card
-      selected={selected}
-      className="min-w-[var(--node-min-width)] cursor-pointer p-[var(--card-padding)]"
-      onDoubleClick={() => setOpen(true)}
-    >
-      {/* Single input port */}
-      {nodeDefinition?.ports.inputs.map((port) => (
-        <Handle
-          key={port.id}
-          type="target"
-          position={Position.Left}
-          id={port.id}
-          className={`h-3 w-3 ${handleClass} !border-2 !border-[var(--text-primary)]`}
-          style={{ top: `50%` }}
-        />
-      ))}
-
-      <CardHeader className="p-0 pb-[var(--space-3)]">
-        <div className="flex items-center gap-[var(--space-2)]">
-          <div className="flex h-6 w-6 items-center justify-center rounded bg-[var(--node-data)] text-sm font-bold text-[var(--text-primary)]">
-            ⏰
+    <>
+      <NodeLayout
+        selected={selected}
+        title={data.identifier.displayName}
+        subtitle={`Starts at ${data.appearanceTime}s`}
+        icon={<Clock3 size={14} />}
+        iconClassName="bg-[var(--node-data)]"
+        inputs={inputs}
+        outputs={outputs}
+        onDoubleClick={() => setOpen(true)}
+        footer="Double-click to edit individual timings"
+        measureDeps={[data.appearanceTime, customAssignments]}
+        className="cursor-pointer"
+      >
+        {customAssignments > 0 ? (
+          <div className="flex items-center justify-between">
+            <span>Custom overrides</span>
+            <span className="font-medium text-[var(--text-primary)]">{customAssignments}</span>
           </div>
-          <span className="font-semibold text-[var(--text-primary)]">
-            {data.identifier.displayName}
-          </span>
-        </div>
-      </CardHeader>
+        ) : (
+          <div className="text-[var(--text-secondary)]">Uses the default time for all objects</div>
+        )}
+      </NodeLayout>
 
-      <CardContent className="space-y-1 p-0 text-xs text-[var(--text-secondary)]">
-        <div>Appears at: {data.appearanceTime}s</div>
-        <div className="pt-1 text-[10px] text-[var(--text-tertiary)]">
-          Double-click to edit per-object times
-        </div>
-      </CardContent>
-
-      {/* Single output port */}
-      {nodeDefinition?.ports.outputs.map((port) => (
-        <Handle
-          key={port.id}
-          type="source"
-          position={Position.Right}
-          id={port.id}
-          className={`h-3 w-3 ${handleClass} !border-2 !border-[var(--text-primary)]`}
-          style={{ top: `50%` }}
-        />
-      ))}
       {open ? (
         <InsertModal isOpen={open} onClose={() => setOpen(false)} nodeId={data.identifier.id} />
       ) : null}
-    </Card>
+    </>
   );
 }

--- a/src/components/workspace/nodes/math-op-node.tsx
+++ b/src/components/workspace/nodes/math-op-node.tsx
@@ -1,138 +1,138 @@
-// src/components/workspace/nodes/math-op-node.tsx - Math operation logic node
 'use client';
 
-import { Handle, Position, type NodeProps } from 'reactflow';
-import { Card, CardHeader, CardContent } from '@/components/ui/card';
-import { getNodeDefinitionWithDynamicPorts } from '@/shared/registry/registry-utils';
-import type { MathOpNodeData } from '@/shared/types/nodes';
+import { useMemo } from 'react';
+import type { NodeProps } from 'reactflow';
 import { Calculator } from 'lucide-react';
+import { getNodeDefinitionWithDynamicPorts } from '@/shared/registry/registry-utils';
+import { NodeLayout, type PortConfig } from './components/node-layout';
+import type { MathOpNodeData } from '@/shared/types/nodes';
+
+function getOperatorLabel(operator: MathOpNodeData['operator']) {
+  switch (operator) {
+    case 'add':
+      return 'Add';
+    case 'subtract':
+      return 'Subtract';
+    case 'multiply':
+      return 'Multiply';
+    case 'divide':
+      return 'Divide';
+    case 'modulo':
+      return 'Modulo';
+    case 'power':
+      return 'Power';
+    case 'sqrt':
+      return 'Square root';
+    case 'abs':
+      return 'Absolute';
+    case 'min':
+      return 'Minimum';
+    case 'max':
+      return 'Maximum';
+    default:
+      return 'Math';
+  }
+}
+
+function getOperatorSymbol(operator: MathOpNodeData['operator']) {
+  switch (operator) {
+    case 'add':
+      return '+';
+    case 'subtract':
+      return '-';
+    case 'multiply':
+      return '×';
+    case 'divide':
+      return '÷';
+    case 'modulo':
+      return '%';
+    case 'power':
+      return '^';
+    case 'sqrt':
+      return '√';
+    case 'abs':
+      return '| |';
+    case 'min':
+      return 'min';
+    case 'max':
+      return 'max';
+    default:
+      return '?';
+  }
+}
 
 export function MathOpNode({ data, selected }: NodeProps<MathOpNodeData>) {
-  const nodeDefinition = getNodeDefinitionWithDynamicPorts(
-    'math_op',
-    data as unknown as Record<string, unknown>
-  );
+  const nodeDefinition = getNodeDefinitionWithDynamicPorts('math_op', data as unknown as Record<string, unknown>);
 
-  const getOperatorDisplay = () => {
-    switch (data.operator) {
-      case 'add':
-        return 'ADD';
-      case 'subtract':
-        return 'SUB';
-      case 'multiply':
-        return 'MUL';
-      case 'divide':
-        return 'DIV';
-      case 'modulo':
-        return 'MOD';
-      case 'power':
-        return 'POW';
-      case 'sqrt':
-        return 'SQRT';
-      case 'abs':
-        return 'ABS';
-      case 'min':
-        return 'MIN';
-      case 'max':
-        return 'MAX';
+  const inputs = useMemo<PortConfig[]>(() => {
+    const definitions = nodeDefinition?.ports.inputs ?? [];
+    if (definitions.length === 0) {
+      return [
+        {
+          id: 'input_1',
+          label: 'Input 1',
+          tooltip: 'Numeric input',
+          handleClassName: 'bg-[var(--node-logic)]',
+          badge: '1',
+        },
+        {
+          id: 'input_2',
+          label: 'Input 2',
+          tooltip: 'Numeric input',
+          handleClassName: 'bg-[var(--node-logic)]',
+          badge: '2',
+        },
+      ];
     }
-  };
 
-  const getOperatorSymbol = () => {
-    switch (data.operator) {
-      case 'add':
-        return '+';
-      case 'subtract':
-        return '-';
-      case 'multiply':
-        return '×';
-      case 'divide':
-        return '÷';
-      case 'modulo':
-        return '%';
-      case 'power':
-        return '^';
-      case 'sqrt':
-        return '√A';
-      case 'abs':
-        return '|A|';
-      case 'min':
-        return 'min';
-      case 'max':
-        return 'max';
+    return definitions.map((port, index) => ({
+      id: port.id,
+      label: `Input ${index + 1}`,
+      tooltip: 'Numeric input',
+      handleClassName: 'bg-[var(--node-logic)]',
+      badge: String(index + 1),
+    }));
+  }, [nodeDefinition]);
+
+  const outputs = useMemo<PortConfig[]>(() => {
+    const definitions = nodeDefinition?.ports.outputs ?? [];
+    if (definitions.length === 0) {
+      return [
+        {
+          id: 'output',
+          label: 'Calculated value',
+          tooltip: 'Result of the math operation',
+          handleClassName: 'bg-[var(--node-logic)]',
+        },
+      ];
     }
-  };
 
-  const isUnaryOperation = () => data.operator === 'sqrt' || data.operator === 'abs';
+    return definitions.map((port) => ({
+      id: port.id,
+      label: 'Calculated value',
+      tooltip: 'Result of the math operation',
+      handleClassName: 'bg-[var(--node-logic)]',
+    }));
+  }, [nodeDefinition]);
 
-  const handleClass = 'bg-[var(--node-logic)]';
+  const isUnary = data.operator === 'sqrt' || data.operator === 'abs';
+  const symbol = getOperatorSymbol(data.operator);
 
   return (
-    <Card selected={selected} className="min-w-[var(--node-min-width)] p-[var(--card-padding)]">
-      {/* Dynamic input ports */}
-      {nodeDefinition?.ports.inputs.map((port, index) => (
-        <Handle
-          key={port.id}
-          type="target"
-          position={Position.Left}
-          id={port.id}
-          className={`h-3 w-3 ${handleClass} !border-2 !border-[var(--text-primary)]`}
-          style={{ top: `${35 + index * 30}%` }}
-        />
-      ))}
-
-      <CardHeader className="p-0 pb-[var(--space-3)]">
-        <div className="flex items-center gap-[var(--space-2)]">
-          <div className="flex h-6 w-6 items-center justify-center rounded bg-[var(--node-logic)] text-[var(--text-primary)]">
-            <Calculator size={12} />
-          </div>
-          <span className="font-semibold text-[var(--text-primary)]">
-            {data.identifier.displayName}
-          </span>
-        </div>
-      </CardHeader>
-
-      <CardContent className="space-y-2 p-0">
-        <div className="rounded border border-[var(--border-primary)] bg-[var(--surface-2)] p-2 text-center">
-          <div className="font-mono text-sm text-[var(--text-primary)]">
-            Math ({getOperatorDisplay()})
-          </div>
-          <div className="mt-1 font-mono text-lg text-[var(--text-primary)]">
-            {isUnaryOperation() ? getOperatorSymbol() : `A ${getOperatorSymbol()} B`}
-          </div>
-        </div>
-
-        <div className="flex items-center justify-between">
-          <span className="text-xs text-[var(--text-secondary)]">Operation:</span>
-          <span className="text-xs font-medium text-[var(--text-primary)]">
-            {getOperatorDisplay()}
-          </span>
-        </div>
-
-        <div className="text-center text-xs">
-          <span className="rounded-[var(--radius-sm)] bg-[var(--accent-100)] px-[var(--space-2)] py-[var(--space-1)] text-[var(--accent-900)]">
-            Number Math
-          </span>
-        </div>
-
-        <div className="mt-3 border-t border-[var(--border-primary)] pt-2">
-          <div className="text-center text-xs text-[var(--text-tertiary)]">
-            {isUnaryOperation() ? '1 Input' : '2 Inputs'} → Number
-          </div>
-        </div>
-      </CardContent>
-
-      {/* Output port */}
-      {nodeDefinition?.ports.outputs.map((port) => (
-        <Handle
-          key={port.id}
-          type="source"
-          position={Position.Right}
-          id={port.id}
-          className={`h-3 w-3 ${handleClass} !border-2 !border-[var(--text-primary)]`}
-          style={{ top: '50%' }}
-        />
-      ))}
-    </Card>
+    <NodeLayout
+      selected={selected}
+      title={data.identifier.displayName}
+      subtitle={getOperatorLabel(data.operator)}
+      icon={<Calculator size={14} />}
+      iconClassName="bg-[var(--node-logic)]"
+      inputs={inputs}
+      outputs={outputs}
+      measureDeps={[data.operator, inputs.length]}
+    >
+      <div className="rounded border border-[var(--border-primary)] bg-[var(--surface-2)] p-[var(--space-2)] text-center font-mono text-sm text-[var(--text-primary)]">
+        {isUnary ? `${symbol}A` : `A ${symbol} B`}
+      </div>
+      <div className="text-xs text-[var(--text-secondary)]">Returns the numeric result of the expression.</div>
+    </NodeLayout>
   );
 }

--- a/src/components/workspace/nodes/media-node.tsx
+++ b/src/components/workspace/nodes/media-node.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { Handle, Position, type NodeProps } from 'reactflow';
-import { Card, CardHeader, CardContent } from '@/components/ui/card';
-import { getNodeDefinition } from '@/shared/registry/registry-utils';
-import type { MediaNodeData } from '@/shared/types/nodes';
+import { useMemo } from 'react';
+import type { NodeProps } from 'reactflow';
 import { Image, Settings } from 'lucide-react';
+import { getNodeDefinition } from '@/shared/registry/registry-utils';
+import { NodeLayout, type PortConfig } from './components/node-layout';
+import type { MediaNodeData } from '@/shared/types/nodes';
 
 export function MediaNode({
   data,
@@ -13,74 +14,83 @@ export function MediaNode({
 }: NodeProps<MediaNodeData> & { onOpenMedia?: () => void }) {
   const nodeDefinition = getNodeDefinition('media');
 
-  const handleDoubleClick = () => {
-    if (onOpenMedia) {
-      onOpenMedia();
-    } else {
-      // Dispatch custom event to open media editor
-      window.dispatchEvent(
-        new CustomEvent('open-media-editor', {
-          detail: { nodeId: data.identifier.id },
-        })
-      );
+  const inputs = useMemo<PortConfig[]>(() => {
+    const definitions = nodeDefinition?.ports.inputs ?? [];
+    if (definitions.length === 0) {
+      return [
+        {
+          id: 'input',
+          label: 'Image input',
+          tooltip: 'Connect an image stream or asset',
+          handleClassName: 'bg-[var(--node-animation)]',
+        },
+      ];
     }
-  };
+
+    return definitions.map((port) => ({
+      id: port.id,
+      label: 'Image input',
+      tooltip: 'Connect an image stream or asset',
+      handleClassName: 'bg-[var(--node-animation)]',
+    }));
+  }, [nodeDefinition]);
+
+  const outputs = useMemo<PortConfig[]>(() => {
+    const definitions = nodeDefinition?.ports.outputs ?? [];
+    if (definitions.length === 0) {
+      return [
+        {
+          id: 'output',
+          label: 'Media output',
+          tooltip: 'Emits the edited media asset',
+          handleClassName: 'bg-[var(--node-animation)]',
+        },
+      ];
+    }
+
+    return definitions.map((port) => ({
+      id: port.id,
+      label: 'Media output',
+      tooltip: 'Emits the edited media asset',
+      handleClassName: 'bg-[var(--node-animation)]',
+    }));
+  }, [nodeDefinition]);
 
   const currentAsset = data.imageAssetId ? 'Selected' : 'No asset';
   const cropInfo = data.cropWidth > 0 ? `${data.cropWidth}×${data.cropHeight}` : 'Full size';
+  const displayInfo = data.displayWidth > 0 ? `${data.displayWidth}×${data.displayHeight}` : 'Auto';
+
+  const handleDoubleClick = () => {
+    if (onOpenMedia) {
+      onOpenMedia();
+      return;
+    }
+
+    window.dispatchEvent(
+      new CustomEvent('open-media-editor', {
+        detail: { nodeId: data.identifier.id },
+      }),
+    );
+  };
 
   return (
-    <Card
+    <NodeLayout
       selected={selected}
-      className="min-w-[var(--node-min-width)] cursor-pointer p-[var(--card-padding)] transition-all hover:bg-[var(--surface-interactive)]"
+      title={data.identifier.displayName}
+      subtitle="Media preparation"
+      icon={<Image size={14} aria-label="Media node icon" />}
+      iconClassName="bg-[var(--node-animation)]"
+      inputs={inputs}
+      outputs={outputs}
       onDoubleClick={handleDoubleClick}
+      measureDeps={[currentAsset, cropInfo, displayInfo]}
+      className="cursor-pointer"
+      headerAccessory={<Settings size={12} className="text-[var(--text-tertiary)]" />}
+      footer="Double-click to edit in the Media tab"
     >
-      <CardHeader className="p-0 pb-[var(--space-3)]">
-        <div className="flex items-center gap-[var(--space-2)]">
-          <div className="flex h-6 w-6 items-center justify-center rounded bg-[var(--node-animation)] text-[var(--text-primary)]">
-            <Image size={12} aria-label="Media node icon" />
-          </div>
-          <div className="min-w-0 flex-1">
-            <div className="truncate font-semibold text-[var(--text-primary)]">
-              {data.identifier.displayName}
-            </div>
-          </div>
-          <Settings size={12} className="text-[var(--text-tertiary)]" />
-        </div>
-      </CardHeader>
-
-      <CardContent className="space-y-1 p-0 text-xs text-[var(--text-secondary)]">
-        <div className="truncate">Asset: {currentAsset}</div>
-        <div>Crop: {cropInfo}</div>
-        <div>
-          Display: {data.displayWidth > 0 ? `${data.displayWidth}×${data.displayHeight}` : 'Auto'}
-        </div>
-        <div className="pt-1 text-[10px] text-[var(--text-tertiary)]">
-          Double-click to edit in Media tab
-        </div>
-      </CardContent>
-
-      {nodeDefinition?.ports.inputs.map((port) => (
-        <Handle
-          key={port.id}
-          type="target"
-          position={Position.Left}
-          id={port.id}
-          className="h-3 w-3 !border-2 !border-[var(--text-primary)] bg-[var(--node-animation)]"
-          style={{ top: '50%' }}
-        />
-      ))}
-
-      {nodeDefinition?.ports.outputs.map((port) => (
-        <Handle
-          key={port.id}
-          type="source"
-          position={Position.Right}
-          id={port.id}
-          className="h-3 w-3 !border-2 !border-[var(--text-primary)] bg-[var(--node-animation)]"
-          style={{ top: '50%' }}
-        />
-      ))}
-    </Card>
+      <div className="text-xs text-[var(--text-secondary)]">Asset: {currentAsset}</div>
+      <div className="text-xs text-[var(--text-secondary)]">Crop: {cropInfo}</div>
+      <div className="text-xs text-[var(--text-secondary)]">Display: {displayInfo}</div>
+    </NodeLayout>
   );
 }

--- a/src/components/workspace/nodes/merge-node.tsx
+++ b/src/components/workspace/nodes/merge-node.tsx
@@ -1,93 +1,59 @@
 'use client';
 
-import { Handle, Position, type NodeProps } from 'reactflow';
-import { Card, CardHeader, CardContent } from '@/components/ui/card';
-
+import { useMemo } from 'react';
+import type { NodeProps } from 'reactflow';
+import { GitMerge } from 'lucide-react';
+import { NodeLayout, type PortConfig } from './components/node-layout';
 import type { MergeNodeData } from '@/shared/types/nodes';
 
 export function MergeNode({ data, selected }: NodeProps<MergeNodeData>) {
-  const portCount = data.inputPortCount || 2;
+  const portCount = Math.max(2, data.inputPortCount ?? 2);
 
-  // Generate dynamic input ports
-  const inputPorts = Array.from({ length: portCount }, (_, i) => ({
-    id: `input${i + 1}`,
-    label: i === 0 ? 'Input 1 (Priority)' : `Input ${i + 1}`,
-  }));
+  const inputs = useMemo<PortConfig[]>(
+    () =>
+      Array.from({ length: portCount }, (_, index) => ({
+        id: `input${index + 1}`,
+        label: index === 0 ? 'Priority stream' : `Stream ${index + 1}`,
+        tooltip:
+          index === 0
+            ? 'First stream wins when objects share an ID'
+            : 'Additional stream merged into the priority result',
+        handleClassName: 'bg-[var(--node-logic)]',
+        badge: String(index + 1),
+      })),
+    [portCount],
+  );
 
-  // Calculate port spacing to avoid overlap
-  const getPortTopPosition = (index: number) => {
-    if (portCount <= 2) {
-      return index === 0 ? '30%' : '70%';
-    } else if (portCount === 3) {
-      return ['25%', '50%', '75%'][index];
-    } else if (portCount === 4) {
-      return ['20%', '40%', '60%', '80%'][index];
-    } else {
-      // 5 ports
-      return ['15%', '30%', '50%', '70%', '85%'][index];
-    }
-  };
-
-  // Dynamic height based on port count for better port spacing
-  const getNodeHeight = () => {
-    if (portCount <= 2) return 'min-h-[120px]';
-    if (portCount === 3) return 'min-h-[140px]';
-    if (portCount === 4) return 'min-h-[160px]';
-    return 'min-h-[180px]'; // 5 ports
-  };
-
-  const handleClass = 'bg-[var(--node-logic)]';
+  const outputs = useMemo<PortConfig[]>(
+    () => [
+      {
+        id: 'output',
+        label: 'Merged stream',
+        tooltip: 'Combined objects with priority conflicts resolved',
+        handleClassName: 'bg-[var(--node-logic)]',
+      },
+    ],
+    [],
+  );
 
   return (
-    <Card
-      className={`min-w-[var(--node-min-width)] p-[var(--card-padding)] ${getNodeHeight()} ${selected ? 'ring-2 ring-[var(--accent-primary)]' : ''}`}
+    <NodeLayout
+      selected={selected}
+      title={data.identifier.displayName}
+      subtitle={`Merge ${portCount} input${portCount === 1 ? '' : 's'}`}
+      icon={<GitMerge size={14} />}
+      iconClassName="bg-[var(--node-logic)]"
+      inputs={inputs}
+      outputs={outputs}
+      measureDeps={[portCount]}
     >
-      {/* Dynamic input ports */}
-      {inputPorts.map((port, index) => (
-        <Handle
-          key={port.id}
-          type="target"
-          position={Position.Left}
-          id={port.id}
-          className={`h-3 w-3 ${handleClass} !border-2 !border-[var(--text-primary)]`}
-          style={{ top: getPortTopPosition(index) }}
-        />
-      ))}
-
-      <CardHeader className="p-0 pb-[var(--space-3)]">
-        <div className="flex items-center gap-[var(--space-2)]">
-          <div className="flex h-6 w-6 items-center justify-center rounded bg-[var(--node-logic)] text-sm font-bold text-[var(--text-primary)]">
-            ⊕
-          </div>
-          <span className="font-semibold text-[var(--text-primary)]">
-            {data.identifier.displayName}
-          </span>
-        </div>
-      </CardHeader>
-
-      <CardContent className="space-y-2 p-0">
-        <div className="flex items-center justify-between">
-          <span className="text-xs text-[var(--text-secondary)]">Ports:</span>
-          <span className="text-xs font-medium text-[var(--text-primary)]">{portCount}</span>
-        </div>
-
-        <div className="text-xs text-[var(--accent-primary)]">Port 1 has merge priority</div>
-
-        <div className="mt-3 border-t border-[var(--border-primary)] pt-2">
-          <div className="text-center text-xs text-[var(--text-tertiary)]">
-            Resolves object ID conflicts
-          </div>
-        </div>
-      </CardContent>
-
-      {/* Single output port */}
-      <Handle
-        type="source"
-        position={Position.Right}
-        id="output"
-        className={`h-3 w-3 ${handleClass} !border-2 !border-[var(--text-primary)]`}
-        style={{ top: '50%' }}
-      />
-    </Card>
+      <div className="flex items-center justify-between text-xs">
+        <span>Priority</span>
+        <span className="font-medium text-[var(--text-primary)]">First connected stream</span>
+      </div>
+      <div className="text-xs text-[var(--text-secondary)]">
+        Later streams fill gaps without overriding existing IDs.
+      </div>
+    </NodeLayout>
   );
 }

--- a/src/components/workspace/nodes/rectangle-node.tsx
+++ b/src/components/workspace/nodes/rectangle-node.tsx
@@ -1,47 +1,39 @@
-// src/components/workspace/nodes/rectangle-node.tsx - Simplified single output port
 'use client';
 
-import { Handle, Position, type NodeProps } from 'reactflow';
-import { Card, CardHeader, CardContent } from '@/components/ui/card';
-import { getNodeDefinition } from '@/shared/registry/registry-utils';
-import type { RectangleNodeData } from '@/shared/types/nodes';
+import { useMemo } from 'react';
+import type { NodeProps } from 'reactflow';
 import { Square as SquareIcon } from 'lucide-react';
+import { NodeLayout, type PortConfig } from './components/node-layout';
+import type { RectangleNodeData } from '@/shared/types/nodes';
 
 export function RectangleNode({ data, selected }: NodeProps<RectangleNodeData>) {
-  const nodeDefinition = getNodeDefinition('rectangle');
+  const outputs = useMemo<PortConfig[]>(
+    () => [
+      {
+        id: 'output',
+        label: 'Rectangle object',
+        tooltip: 'Provides the generated rectangle geometry',
+        handleClassName: 'bg-[var(--node-geometry)]',
+      },
+    ],
+    [],
+  );
 
   return (
-    <Card selected={selected} className="min-w-[var(--node-min-width)] p-[var(--card-padding)]">
-      <CardHeader className="p-0 pb-[var(--space-3)]">
-        <div className="flex items-center gap-[var(--space-2)]">
-          <div
-            className="flex h-6 w-6 items-center justify-center rounded text-[var(--text-primary)]"
-            style={{ backgroundColor: '#4444ff' }} // Canvas default
-          >
-            <SquareIcon size={12} />
-          </div>
-          <span className="font-semibold text-[var(--text-primary)]">
-            {data.identifier.displayName}
-          </span>
-        </div>
-      </CardHeader>
-
-      <CardContent className="space-y-1 p-0 text-xs text-[var(--text-secondary)]">
-        <div>Width: {data.width || 100}px</div>
-        <div>Height: {data.height || 60}px</div>
-      </CardContent>
-
-      {/* Single output port */}
-      {nodeDefinition?.ports.outputs.map((port) => (
-        <Handle
-          key={port.id}
-          type="source"
-          position={Position.Right}
-          id={port.id}
-          className={`h-3 w-3 !border-2 !border-[var(--text-primary)] bg-[var(--node-geometry)]`}
-          style={{ top: `50%` }}
-        />
-      ))}
-    </Card>
+    <NodeLayout
+      selected={selected}
+      title={data.identifier.displayName}
+      subtitle="Rectangle geometry"
+      icon={<SquareIcon size={14} />}
+      iconClassName="bg-[var(--node-geometry)]"
+      inputs={[]}
+      outputs={outputs}
+      measureDeps={[data.width, data.height]}
+    >
+      <div className="flex items-center justify-between">
+        <span>Size</span>
+        <span className="font-medium text-[var(--text-primary)]">{data.width} × {data.height}px</span>
+      </div>
+    </NodeLayout>
   );
 }

--- a/src/components/workspace/nodes/scene-node.tsx
+++ b/src/components/workspace/nodes/scene-node.tsx
@@ -1,102 +1,95 @@
-// src/components/workspace/nodes/scene-node.tsx - Simplified single input port
 'use client';
 
-import { Handle, Position, type NodeProps } from 'reactflow';
-import { Card, CardHeader, CardContent } from '@/components/ui/card';
-import { getNodeDefinition } from '@/shared/registry/registry-utils';
-import type { SceneNodeData } from '@/shared/types/nodes';
+import { useMemo } from 'react';
+import type { NodeProps } from 'reactflow';
 import { MonitorPlay } from 'lucide-react';
+import { getNodeDefinition } from '@/shared/registry/registry-utils';
+import { NodeLayout, type PortConfig } from './components/node-layout';
+import type { SceneNodeData } from '@/shared/types/nodes';
+
+function formatResolution(width: number, height: number) {
+  if (width === 1920 && height === 1080) return 'FHD';
+  if (width === 1280 && height === 720) return 'HD';
+  if (width === 3840 && height === 2160) return '4K';
+  if (width === 1080 && height === 1080) return 'Square';
+  return 'Custom';
+}
 
 export function SceneNode({ data, selected }: NodeProps<SceneNodeData>) {
   const nodeDefinition = getNodeDefinition('scene');
 
-  const getResolutionLabel = (width: number, height: number) => {
-    if (width === 1920 && height === 1080) return 'FHD';
-    if (width === 1280 && height === 720) return 'HD';
-    if (width === 3840 && height === 2160) return '4K';
-    if (width === 1080 && height === 1080) return 'Square';
-    return 'Custom';
-  };
+  const inputs = useMemo<PortConfig[]>(() => {
+    const definitions = nodeDefinition?.ports.inputs ?? [];
+    if (definitions.length === 0) {
+      return [
+        {
+          id: 'input',
+          label: 'Scene assets',
+          tooltip: 'Objects and tracks entering the scene',
+          handleClassName: 'bg-[var(--node-output)]',
+        },
+      ];
+    }
 
-  const getQualityLabel = (crf: number) => {
-    if (crf <= 18) return 'High';
-    if (crf <= 28) return 'Medium';
-    return 'Low';
-  };
+    return definitions.map((port) => ({
+      id: port.id,
+      label: 'Scene assets',
+      tooltip: 'Objects and tracks entering the scene',
+      handleClassName: 'bg-[var(--node-output)]',
+    }));
+  }, [nodeDefinition]);
 
-  const handleClass = 'bg-[var(--node-output)]';
+  const outputs = useMemo<PortConfig[]>(() => {
+    const definitions = nodeDefinition?.ports.outputs ?? [];
+    if (definitions.length === 0) {
+      return [
+        {
+          id: 'output',
+          label: 'Scene timeline',
+          tooltip: 'Emits the configured scene for downstream nodes',
+          handleClassName: 'bg-[var(--node-output)]',
+        },
+      ];
+    }
+
+    return definitions.map((port) => ({
+      id: port.id,
+      label: 'Scene timeline',
+      tooltip: 'Emits the configured scene for downstream nodes',
+      handleClassName: 'bg-[var(--node-output)]',
+    }));
+  }, [nodeDefinition]);
+
+  const fpsSummary = `${data.fps} fps`;
 
   return (
-    <Card selected={selected} className="min-w-[var(--node-min-width)] p-[var(--card-padding)]">
-      {/* Single input port */}
-      {nodeDefinition?.ports.inputs.map((port) => (
-        <Handle
-          key={port.id}
-          type="target"
-          position={Position.Left}
-          id={port.id}
-          className={`h-3 w-3 ${handleClass} !border-2 !border-[var(--text-primary)]`}
-          style={{ top: `50%` }}
-        />
-      ))}
-
-      <CardHeader className="p-0 pb-[var(--space-3)]">
-        <div className="flex items-center gap-[var(--space-2)]">
-          <div className="flex h-6 w-6 items-center justify-center rounded bg-[var(--node-output)] text-[var(--text-primary)]">
-            <MonitorPlay size={12} />
-          </div>
-          <div className="min-w-0 flex-1">
-            <div className="truncate font-semibold text-[var(--text-primary)]">
-              {data.identifier.displayName}
-            </div>
-          </div>
-        </div>
-      </CardHeader>
-
-      <CardContent className="space-y-2 p-0 text-xs text-[var(--text-secondary)]">
-        <div className="flex items-center justify-between">
-          <span>Resolution</span>
-          <span className="font-medium text-[var(--text-primary)]">
-            {getResolutionLabel(data.width, data.height)} ({data.width}×{data.height})
-          </span>
-        </div>
-
-        <div className="flex items-center justify-between">
-          <span>Frame Rate</span>
-          <span className="font-medium text-[var(--text-primary)]">{data.fps} FPS</span>
-        </div>
-
-        <div className="flex items-center justify-between">
-          <span>Duration</span>
-          <span className="font-medium text-[var(--text-primary)]">{data.duration}s</span>
-        </div>
-
-        <div className="flex items-center justify-between">
-          <span>Background</span>
-          <div className="flex items-center gap-[var(--space-2)]">
-            <div
-              className="h-4 w-4 rounded border border-[var(--border-primary)]"
-              style={{ backgroundColor: data.backgroundColor }}
-            />
-            <span className="text-xs font-medium text-[var(--text-primary)]">
-              {data.backgroundColor.toUpperCase()}
-            </span>
-          </div>
-        </div>
-
-        <div className="flex items-center justify-between">
-          <span>Quality</span>
-          <span className="font-medium text-[var(--text-primary)]">
-            {getQualityLabel(data.videoCrf)} ({data.videoPreset})
-          </span>
-        </div>
-
-        <div className="mt-4 border-t border-[var(--border-primary)] pt-3">
-          <div className="text-center text-xs text-[var(--text-tertiary)]">
-            {data.width}×{data.height} @ {data.fps}fps
-          </div>
-        </div>
-      </CardContent>
-    </Card>
+    <NodeLayout
+      selected={selected}
+      title={data.identifier.displayName}
+      subtitle={`${formatResolution(data.width, data.height)} • ${fpsSummary}`}
+      icon={<MonitorPlay size={14} />}
+      iconClassName="bg-[var(--node-output)]"
+      inputs={inputs}
+      outputs={outputs}
+      measureDeps={[data.width, data.height, data.fps, data.duration, data.backgroundColor]}
+    >
+      <div className="flex items-center justify-between text-xs">
+        <span>Duration</span>
+        <span className="font-medium text-[var(--text-primary)]">{data.duration}s</span>
+      </div>
+      <div className="flex items-center justify-between text-xs">
+        <span>Background</span>
+        <span className="flex items-center gap-[var(--space-1)]">
+          <span
+            className="h-3 w-3 rounded border border-[var(--border-primary)]"
+            style={{ backgroundColor: data.backgroundColor }}
+          />
+          <span className="font-mono text-[var(--text-primary)]">{data.backgroundColor.toUpperCase()}</span>
+        </span>
+      </div>
+      <div className="text-xs text-[var(--text-secondary)]">
+        Quality preset: <span className="font-medium text-[var(--text-primary)]">{data.videoPreset}</span>
+      </div>
+    </NodeLayout>
   );
 }

--- a/src/components/workspace/nodes/text-node.tsx
+++ b/src/components/workspace/nodes/text-node.tsx
@@ -1,49 +1,44 @@
 'use client';
 
-import { Handle, Position, type NodeProps } from 'reactflow';
-import { Card, CardHeader, CardContent } from '@/components/ui/card';
-import { getNodeDefinition } from '@/shared/registry/registry-utils';
-import type { TextNodeData } from '@/shared/types/nodes';
+import { useMemo } from 'react';
+import type { NodeProps } from 'reactflow';
 import { Type } from 'lucide-react';
+import { NodeLayout, type PortConfig } from './components/node-layout';
+import type { TextNodeData } from '@/shared/types/nodes';
 
 export function TextNode({ data, selected }: NodeProps<TextNodeData>) {
-  const nodeDefinition = getNodeDefinition('text');
+  const displayContent = useMemo(() => {
+    const content = data.content || 'Hello World';
+    return content.length > 40 ? `${content.slice(0, 37)}…` : content;
+  }, [data.content]);
 
-  const displayContent =
-    data.content?.length > 20
-      ? data.content.substring(0, 20) + '...'
-      : data.content || 'Hello World';
+  const outputs = useMemo<PortConfig[]>(
+    () => [
+      {
+        id: 'output',
+        label: 'Text object',
+        tooltip: 'Outputs the configured text element',
+        handleClassName: 'bg-[var(--node-text)]',
+      },
+    ],
+    [],
+  );
 
   return (
-    <Card selected={selected} className="min-w-[var(--node-min-width)] p-[var(--card-padding)]">
-      <CardHeader className="p-0 pb-[var(--space-3)]">
-        <div className="flex items-center gap-[var(--space-2)]">
-          <div className="flex h-6 w-6 items-center justify-center rounded bg-[var(--node-text)] text-[var(--text-primary)]">
-            <Type size={12} />
-          </div>
-          <span className="font-semibold text-[var(--text-primary)]">
-            {data.identifier.displayName}
-          </span>
-        </div>
-      </CardHeader>
-
-      <CardContent className="space-y-1 p-0 text-xs text-[var(--text-secondary)]">
-        <div className="rounded bg-[var(--surface-2)] p-1 font-mono text-[10px]">
-          &ldquo;{displayContent}&rdquo;
-        </div>
-        <div>Size: {data.fontSize || 24}px</div>
-      </CardContent>
-
-      {nodeDefinition?.ports.outputs.map((port) => (
-        <Handle
-          key={port.id}
-          type="source"
-          position={Position.Right}
-          id={port.id}
-          className="h-3 w-3 !border-2 !border-[var(--text-primary)] bg-[var(--node-text)]"
-          style={{ top: '50%' }}
-        />
-      ))}
-    </Card>
+    <NodeLayout
+      selected={selected}
+      title={data.identifier.displayName}
+      subtitle={displayContent}
+      icon={<Type size={14} />}
+      iconClassName="bg-[var(--node-text)]"
+      inputs={[]}
+      outputs={outputs}
+      measureDeps={[data.fontSize, displayContent]}
+    >
+      <div className="flex items-center justify-between">
+        <span>Font size</span>
+        <span className="font-medium text-[var(--text-primary)]">{data.fontSize}px</span>
+      </div>
+    </NodeLayout>
   );
 }

--- a/src/components/workspace/nodes/triangle-node.tsx
+++ b/src/components/workspace/nodes/triangle-node.tsx
@@ -1,46 +1,39 @@
-// src/components/workspace/nodes/triangle-node.tsx - Simplified single output port
 'use client';
 
-import { Handle, Position, type NodeProps } from 'reactflow';
-import { Card, CardHeader, CardContent } from '@/components/ui/card';
-import { getNodeDefinition } from '@/shared/registry/registry-utils';
-import type { TriangleNodeData } from '@/shared/types/nodes';
+import { useMemo } from 'react';
+import type { NodeProps } from 'reactflow';
 import { Triangle as TriangleIcon } from 'lucide-react';
+import { NodeLayout, type PortConfig } from './components/node-layout';
+import type { TriangleNodeData } from '@/shared/types/nodes';
 
 export function TriangleNode({ data, selected }: NodeProps<TriangleNodeData>) {
-  const nodeDefinition = getNodeDefinition('triangle');
+  const outputs = useMemo<PortConfig[]>(
+    () => [
+      {
+        id: 'output',
+        label: 'Triangle object',
+        tooltip: 'Provides the generated triangle geometry',
+        handleClassName: 'bg-[var(--node-geometry)]',
+      },
+    ],
+    [],
+  );
 
   return (
-    <Card selected={selected} className="min-w-[var(--node-min-width)] p-[var(--card-padding)]">
-      <CardHeader className="p-0 pb-[var(--space-3)]">
-        <div className="flex items-center gap-[var(--space-2)]">
-          <div
-            className="flex h-6 w-6 items-center justify-center rounded text-[var(--text-primary)]"
-            style={{ backgroundColor: '#4444ff' }} // Canvas default
-          >
-            <TriangleIcon size={12} />
-          </div>
-          <span className="font-semibold text-[var(--text-primary)]">
-            {data.identifier.displayName}
-          </span>
-        </div>
-      </CardHeader>
-
-      <CardContent className="space-y-1 p-0 text-xs text-[var(--text-secondary)]">
-        <div>Size: {data.size || 80}px</div>
-      </CardContent>
-
-      {/* Single output port */}
-      {nodeDefinition?.ports.outputs.map((port) => (
-        <Handle
-          key={port.id}
-          type="source"
-          position={Position.Right}
-          id={port.id}
-          className={`h-3 w-3 !border-2 !border-[var(--text-primary)] bg-[var(--node-geometry)]`}
-          style={{ top: `50%` }}
-        />
-      ))}
-    </Card>
+    <NodeLayout
+      selected={selected}
+      title={data.identifier.displayName}
+      subtitle="Basic triangle geometry"
+      icon={<TriangleIcon size={14} />}
+      iconClassName="bg-[var(--node-geometry)]"
+      inputs={[]}
+      outputs={outputs}
+      measureDeps={[data.size]}
+    >
+      <div className="flex items-center justify-between">
+        <span>Edge length</span>
+        <span className="font-medium text-[var(--text-primary)]">{data.size}px</span>
+      </div>
+    </NodeLayout>
   );
 }


### PR DESCRIPTION
## Summary
- introduce a reusable NodeLayout wrapper that measures port labels, spaces handles, and keeps node content in a protected center column
- restyle every flow node to use the shared layout with clear input/output captions and concise summaries so text never overlaps port badges
- preserve interactive affordances such as batch key editing and media/timeline open actions while surfacing the key state inline

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68ceab445e588322a03810255bc2b754