### PR TITLE
Refine workspace node visuals

### DIFF
--- a/src/components/workspace/nodes/components/node-layout.tsx
+++ b/src/components/workspace/nodes/components/node-layout.tsx
@@ -65,31 +65,22 @@ function PortBadge({ side, config, onRef }: PortBadgeProps) {
   const accessibleLabel = tooltipSections.join('. ');
 
   const indicator = icon ? (
-    <span
-      className="pointer-events-none text-[var(--text-tertiary)] transition-colors duration-[var(--duration-fast)] group-hover:text-[var(--text-primary)]"
-      aria-hidden="true"
-    >
+    <span className="node-port-indicator node-port-indicator--icon" aria-hidden="true">
       {icon}
     </span>
   ) : badge ? (
-    <span
-      className="pointer-events-none inline-flex h-2 w-2 items-center justify-center rounded-full bg-[var(--surface-3)] text-[8px] font-semibold text-[var(--text-tertiary)] transition-colors duration-[var(--duration-fast)] group-hover:bg-[var(--accent-primary)] group-hover:text-[var(--text-primary)]"
-      aria-hidden="true"
-    >
+    <span className="node-port-indicator node-port-indicator--badge" aria-hidden="true">
       {badge}
     </span>
   ) : (
-    <span
-      className="pointer-events-none block h-2 w-2 rounded-full bg-[var(--text-tertiary)] transition-transform duration-[var(--duration-fast)] group-hover:scale-110 group-hover:bg-[var(--accent-primary)]"
-      aria-hidden="true"
-    />
+    <span className="node-port-indicator node-port-indicator--dot" aria-hidden="true" />
   );
 
   return (
     <div
       ref={onRef}
       className={cn(
-        'port-badge group text-[10px] font-medium focus-visible:outline-none',
+        'port-badge node-port-badge group focus-visible:outline-none',
         side === 'input' ? 'ml-auto' : 'mr-auto'
       )}
       data-direction={side}
@@ -167,8 +158,16 @@ export function NodeLayout({
     <Card
       selected={selected}
       onDoubleClick={onDoubleClick}
-      className={cn('min-w-[var(--node-min-width)] p-[var(--card-padding)]', className)}
+      className={cn(
+        'node-card group relative isolate min-w-[var(--node-min-width)] overflow-hidden p-0',
+        selected && 'node-card--selected',
+        className
+      )}
     >
+      <div className="node-card__halo" aria-hidden="true" />
+      <div className="node-card__sheen" aria-hidden="true" />
+
+      <div className="node-card__content" style={{ gridTemplateColumns }}>
       {hasInputs &&
         inputs.map((port, index) => (
           <Handle
@@ -195,70 +194,75 @@ export function NodeLayout({
           />
         ))}
 
-      <div className="grid items-stretch gap-x-[var(--space-3)]" style={{ gridTemplateColumns }}>
         {hasInputs && (
-          <div className="flex h-full min-h-[80px] flex-col justify-evenly gap-[var(--space-2)] pr-[var(--space-1)]">
+          <div className="node-port-column node-port-column--input">
             {inputs.map((port) => (
-              <div key={port.id} className="flex w-full justify-end">
+              <div key={port.id} className="node-port-slot node-port-slot--input">
                 <PortBadge side="input" config={port} onRef={noop} />
               </div>
             ))}
           </div>
         )}
 
-        <div className="flex min-h-[96px] flex-col gap-[var(--space-3)]">
-          <div className="flex flex-col gap-[var(--space-2)]">
-            <div className="flex items-start justify-between gap-[var(--space-3)]">
-              <div className="flex min-w-0 items-start gap-[var(--space-2)]">
-                <div
-                  className={cn(
-                    'flex h-8 w-8 shrink-0 items-center justify-center rounded-[var(--radius-sm)] text-[var(--text-primary)]',
-                    iconClassName
-                  )}
-                >
-                  {icon}
-                </div>
-                <div className="min-w-0">
+        <div className="node-core">
+          <div className="node-core__glare" aria-hidden="true" />
+
+          <div className="node-core__inner">
+            <div className="flex flex-col gap-[var(--space-2)]">
+              <div className="flex items-start justify-between gap-[var(--space-3)]">
+                <div className="flex min-w-0 items-start gap-[var(--space-2)]">
                   <div
-                    className="truncate text-sm font-semibold text-[var(--text-primary)]"
-                    title={title}
+                    className={cn(
+                      'node-core__icon-swatch flex h-9 w-9 shrink-0 items-center justify-center text-[var(--text-primary)]',
+                      iconClassName
+                    )}
                   >
-                    {title}
+                    <span className="relative z-[1] flex h-5 w-5 items-center justify-center">{icon}</span>
                   </div>
-                  {subtitle ? (
+                  <div className="min-w-0">
                     <div
-                      className="mt-[2px] text-xs text-[var(--text-secondary)]"
-                      style={TITLE_LINE_CLAMP_STYLE}
-                      title={subtitle}
+                      className="truncate text-sm font-semibold tracking-tight text-[var(--text-primary)]"
+                      title={title}
                     >
-                      {subtitle}
+                      {title}
                     </div>
-                  ) : null}
+                    {subtitle ? (
+                      <div
+                        className="mt-[2px] text-xs font-medium text-[var(--text-secondary)]/85"
+                        style={TITLE_LINE_CLAMP_STYLE}
+                        title={subtitle}
+                      >
+                        {subtitle}
+                      </div>
+                    ) : null}
+                  </div>
                 </div>
+                {headerAccessory ? (
+                  <div className="shrink-0 text-[11px] font-medium uppercase tracking-[0.12em] text-[var(--text-tertiary)]">
+                    {headerAccessory}
+                  </div>
+                ) : null}
               </div>
-              {headerAccessory ? (
-                <div className="shrink-0 text-xs text-[var(--text-tertiary)]">
-                  {headerAccessory}
-                </div>
-              ) : null}
             </div>
+
+            {children ? (
+              <div className="flex flex-col gap-[var(--space-2)] text-xs text-[var(--text-secondary)]">
+                {children}
+              </div>
+            ) : null}
+
+            {footer ? (
+              <div className="node-core__footer mt-auto text-[11px] font-medium text-[var(--text-tertiary)]">
+                {footer}
+              </div>
+            ) : null}
           </div>
-
-          {children ? (
-            <div className="flex flex-col gap-[var(--space-2)] text-xs text-[var(--text-secondary)]">
-              {children}
-            </div>
-          ) : null}
-
-          {footer ? (
-            <div className="mt-auto text-xs text-[var(--text-tertiary)]">{footer}</div>
-          ) : null}
         </div>
 
         {hasOutputs && (
-          <div className="flex h-full min-h-[80px] flex-col justify-evenly gap-[var(--space-2)] pl-[var(--space-1)]">
+          <div className="node-port-column node-port-column--output">
             {outputs.map((port) => (
-              <div key={port.id} className="flex w-full justify-start">
+              <div key={port.id} className="node-port-slot node-port-slot--output">
                 <PortBadge side="output" config={port} onRef={noop} />
               </div>
             ))}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -480,27 +480,317 @@ body {
   cursor: crosshair;
 }
 
-/* Compact port badges with hover tooltips */
+/* Workspace node glassmorphism styling */
+.node-card {
+  position: relative;
+  overflow: hidden;
+  isolation: isolate;
+}
+
+.node-card__halo,
+.node-card__sheen {
+  position: absolute;
+  inset: -1px;
+  border-radius: inherit;
+  pointer-events: none;
+  z-index: 0;
+  transition:
+    opacity var(--duration-fast) var(--easing-standard),
+    transform var(--duration-fast) var(--easing-standard);
+}
+
+.node-card__halo {
+  background:
+    radial-gradient(circle at 12% -20%, rgba(139, 92, 246, 0.35), transparent 60%),
+    radial-gradient(circle at 85% 120%, rgba(59, 130, 246, 0.3), transparent 70%);
+  opacity: 0.35;
+}
+
+.node-card__sheen {
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.25), transparent 65%);
+  opacity: 0.18;
+  mix-blend-mode: screen;
+}
+
+.node-card:hover .node-card__halo,
+.node-card:focus-within .node-card__halo {
+  opacity: 0.45;
+}
+
+.node-card:hover .node-card__sheen,
+.node-card:focus-within .node-card__sheen {
+  opacity: 0.26;
+  transform: translate3d(0, -4px, 0);
+}
+
+.node-card--selected .node-card__halo {
+  opacity: 0.55;
+}
+
+.node-card--selected .node-card__sheen {
+  opacity: 0.32;
+}
+
+.node-card__content {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  align-items: stretch;
+  gap: var(--space-3);
+  padding: var(--card-padding);
+}
+
+.node-port-column {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding-block: var(--space-3);
+}
+
+.node-port-column--input {
+  align-items: flex-end;
+  padding-right: var(--space-1);
+}
+
+.node-port-column--output {
+  align-items: flex-start;
+  padding-left: var(--space-1);
+}
+
+.node-port-column::before {
+  content: '';
+  position: absolute;
+  top: var(--space-2);
+  bottom: var(--space-2);
+  width: 1px;
+  border-radius: 9999px;
+  background: linear-gradient(180deg, transparent, rgba(139, 92, 246, 0.45), transparent);
+  opacity: 0.35;
+  transition:
+    opacity var(--duration-fast) var(--easing-standard),
+    transform var(--duration-fast) var(--easing-standard);
+}
+
+.node-port-column--input::before {
+  right: 2px;
+}
+
+.node-port-column--output::before {
+  left: 2px;
+}
+
+.node-card:hover .node-port-column::before,
+.node-card:focus-within .node-port-column::before,
+.node-card--selected .node-port-column::before {
+  opacity: 0.75;
+  transform: scaleY(1.05);
+}
+
+.node-port-slot {
+  position: relative;
+  display: flex;
+  width: 100%;
+  padding-block: var(--space-1);
+}
+
+.node-port-slot--input {
+  justify-content: flex-end;
+}
+
+.node-port-slot--output {
+  justify-content: flex-start;
+}
+
+.node-port-slot::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  width: 18px;
+  height: 1px;
+  border-radius: 9999px;
+  background: linear-gradient(90deg, rgba(139, 92, 246, 0.45), transparent);
+  opacity: 0.35;
+  transform: translateY(-50%);
+  transition:
+    opacity var(--duration-fast) var(--easing-standard),
+    width var(--duration-fast) var(--easing-standard);
+  z-index: 0;
+}
+
+.node-port-slot--input::after {
+  right: -6px;
+  transform-origin: right center;
+  background: linear-gradient(270deg, rgba(139, 92, 246, 0.5), transparent);
+}
+
+.node-port-slot--output::after {
+  left: -6px;
+  transform-origin: left center;
+}
+
+.node-card:hover .node-port-slot::after,
+.node-card:focus-within .node-port-slot::after,
+.node-card--selected .node-port-slot::after {
+  opacity: 0.8;
+  width: 22px;
+}
+
+.node-core {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  min-height: 104px;
+  gap: var(--space-3);
+  border-radius: calc(var(--radius-sm) - 1px);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background:
+    linear-gradient(160deg, rgba(148, 163, 235, 0.08) 0%, rgba(12, 12, 20, 0.7) 40%, rgba(12, 12, 20, 0.92) 100%);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.08),
+    inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+  padding: var(--space-3);
+  overflow: hidden;
+}
+
+.node-core__glare {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background:
+    radial-gradient(circle at 80% 0%, rgba(59, 130, 246, 0.25), transparent 65%),
+    radial-gradient(circle at 0% 100%, rgba(139, 92, 246, 0.18), transparent 60%);
+  opacity: 0;
+  transition:
+    opacity var(--duration-fast) var(--easing-standard),
+    transform var(--duration-fast) var(--easing-standard);
+}
+
+.node-card:hover .node-core__glare,
+.node-card:focus-within .node-core__glare,
+.node-card--selected .node-core__glare {
+  opacity: 0.75;
+  transform: translate3d(0, -4px, 0);
+}
+
+.node-core__inner {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.node-core__icon-swatch {
+  position: relative;
+  border-radius: calc(var(--radius-sm) - 1px);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.12),
+    0 10px 22px rgba(0, 0, 0, 0.45);
+  overflow: hidden;
+  background: rgba(12, 12, 20, 0.82);
+}
+
+.node-core__icon-swatch::after {
+  content: '';
+  position: absolute;
+  inset: 1px;
+  border-radius: inherit;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.25), transparent 60%);
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+.node-card:hover .node-core__icon-swatch::after,
+.node-card:focus-within .node-core__icon-swatch::after,
+.node-card--selected .node-core__icon-swatch::after {
+  opacity: 0.85;
+}
+
+.node-core__footer {
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+  opacity: 0.85;
+}
+
+.node-port-badge {
+  backdrop-filter: blur(8px);
+}
+
+.node-port-indicator {
+  pointer-events: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 9999px;
+  color: rgba(226, 232, 240, 0.85);
+  transition:
+    transform var(--duration-fast) var(--easing-standard),
+    color var(--duration-fast) var(--easing-standard);
+}
+
+.node-port-indicator--icon,
+.node-port-indicator--badge {
+  width: 0.75rem;
+  height: 0.75rem;
+  font-size: 0.55rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.node-port-indicator--icon svg {
+  width: 0.6rem;
+  height: 0.6rem;
+}
+
+.node-port-indicator--dot {
+  width: 0.42rem;
+  height: 0.42rem;
+  border-radius: 9999px;
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.72), rgba(255, 255, 255, 0));
+  box-shadow: 0 0 10px rgba(139, 92, 246, 0.45);
+}
+
+.node-port-badge:hover .node-port-indicator,
+.node-port-badge:focus-visible .node-port-indicator {
+  transform: scale(1.08);
+  color: var(--text-primary);
+}
+
+/* Premium port badges with hover tooltips */
 .port-badge {
   position: relative;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 0.75rem;
-  min-width: 0.75rem;
-  height: 0.75rem;
+  width: 0.95rem;
+  min-width: 0.95rem;
+  height: 0.95rem;
+  padding: 1px;
   border-radius: 9999px;
-  background-color: var(--surface-2);
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  color: var(--text-tertiary);
+  background:
+    radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.38), transparent 65%),
+    rgba(16, 16, 26, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  color: var(--text-primary);
   cursor: pointer;
-  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.06);
+  box-shadow:
+    inset 0 1px 1px rgba(255, 255, 255, 0.25),
+    0 2px 12px rgba(30, 64, 175, 0.35),
+    0 0 0 1px rgba(255, 255, 255, 0.05);
   transition:
-    background-color var(--duration-fast) var(--easing-standard),
+    transform var(--duration-fast) var(--easing-standard),
+    background var(--duration-fast) var(--easing-standard),
     border-color var(--duration-fast) var(--easing-standard),
     box-shadow var(--duration-fast) var(--easing-standard),
     color var(--duration-fast) var(--easing-standard);
   touch-action: manipulation;
+  z-index: 1;
 }
 
 .port-badge:focus {
@@ -509,21 +799,24 @@ body {
 
 .port-badge:hover,
 .port-badge:focus-visible {
-  background-color: var(--surface-interactive);
-  border-color: var(--accent-primary);
-  color: var(--text-primary);
+  background:
+    radial-gradient(circle at 35% 35%, rgba(255, 255, 255, 0.55), transparent 55%),
+    linear-gradient(135deg, rgba(139, 92, 246, 0.45), rgba(59, 130, 246, 0.3));
+  border-color: rgba(255, 255, 255, 0.32);
   box-shadow:
-    0 0 0 1px var(--purple-shadow-subtle),
-    0 0 14px rgba(139, 92, 246, 0.35);
+    inset 0 1px 2px rgba(255, 255, 255, 0.35),
+    0 0 0 1px rgba(255, 255, 255, 0.12),
+    0 12px 24px rgba(23, 23, 36, 0.55);
+  transform: scale(1.08);
 }
 
 .port-badge::after {
   content: attr(data-tooltip);
   position: absolute;
   top: 50%;
-  left: calc(100% + 12px);
+  left: calc(100% + 16px);
   right: auto;
-  transform: translate3d(0, -50%, 0) translateX(6px);
+  transform: translate3d(0, -50%, 0) translateX(8px);
   opacity: 0;
   pointer-events: none;
   background: rgba(10, 10, 18, 0.94);
@@ -545,8 +838,8 @@ body {
 
 .port-badge[data-direction='input']::after {
   left: auto;
-  right: calc(100% + 12px);
-  transform: translate3d(0, -50%, 0) translateX(-6px);
+  right: calc(100% + 16px);
+  transform: translate3d(0, -50%, 0) translateX(-8px);
   text-align: right;
 }
 


### PR DESCRIPTION
## Summary
- restyle the shared node layout to introduce glassmorphic overlays, richer headers, and sculpted port columns without changing behaviour
- refresh global workspace styles for node shells, port indicators, and tooltips to align with the workspace glass aesthetic

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cec56a9608832290df906098496632